### PR TITLE
feat(backend): add configuration and error handling

### DIFF
--- a/apps/backend/Cargo.toml
+++ b/apps/backend/Cargo.toml
@@ -11,3 +11,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rusqlite = { version = "0.31", features = ["bundled"] }
 refinery = { version = "0.8", features = ["rusqlite"] }
+config = "0.14"
+thiserror = "1.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/apps/backend/src/config.rs
+++ b/apps/backend/src/config.rs
@@ -1,0 +1,456 @@
+//! Configuration module for the LCARS backend.
+//!
+//! Loads configuration from `config.toml` with environment variable overrides.
+
+use config::{Config as ConfigLoader, Environment, File};
+use serde::Deserialize;
+use std::path::PathBuf;
+
+use crate::error::AppError;
+
+/// Main application configuration
+#[derive(Debug, Clone, Deserialize)]
+pub struct Config {
+    #[serde(default)]
+    pub server: ServerConfig,
+    #[serde(default)]
+    pub database: DatabaseConfig,
+    #[serde(default)]
+    pub tmdb: TmdbConfig,
+    #[serde(default)]
+    pub musicbrainz: MusicBrainzConfig,
+    #[serde(default)]
+    pub torrent: TorrentConfig,
+    #[serde(default)]
+    pub storage: StorageConfig,
+    #[serde(default)]
+    pub scheduler: SchedulerConfig,
+}
+
+/// Server configuration
+#[derive(Clone, Deserialize)]
+pub struct ServerConfig {
+    #[serde(default = "default_host")]
+    pub host: String,
+    #[serde(default = "default_port")]
+    pub port: u16,
+    pub jwt_secret: Option<String>,
+}
+
+// Custom Debug implementation to avoid exposing jwt_secret
+impl std::fmt::Debug for ServerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ServerConfig")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field(
+                "jwt_secret",
+                &self.jwt_secret.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
+    }
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            host: default_host(),
+            port: default_port(),
+            jwt_secret: None,
+        }
+    }
+}
+
+fn default_host() -> String {
+    "0.0.0.0".to_string()
+}
+
+fn default_port() -> u16 {
+    8080
+}
+
+/// Database configuration
+#[derive(Debug, Clone, Deserialize)]
+pub struct DatabaseConfig {
+    #[serde(default = "default_db_path")]
+    pub path: PathBuf,
+}
+
+impl Default for DatabaseConfig {
+    fn default() -> Self {
+        Self {
+            path: default_db_path(),
+        }
+    }
+}
+
+fn default_db_path() -> PathBuf {
+    PathBuf::from("./data/lcars.db")
+}
+
+/// TMDB API configuration
+#[derive(Clone, Deserialize, Default)]
+pub struct TmdbConfig {
+    pub api_key: Option<String>,
+}
+
+// Custom Debug implementation to avoid exposing api_key
+impl std::fmt::Debug for TmdbConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TmdbConfig")
+            .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
+            .finish()
+    }
+}
+
+/// MusicBrainz configuration
+#[derive(Debug, Clone, Deserialize)]
+pub struct MusicBrainzConfig {
+    #[serde(default = "default_rate_limit")]
+    pub rate_limit_ms: u64,
+}
+
+impl Default for MusicBrainzConfig {
+    fn default() -> Self {
+        Self {
+            rate_limit_ms: default_rate_limit(),
+        }
+    }
+}
+
+fn default_rate_limit() -> u64 {
+    1000 // MusicBrainz requires max 1 request/second
+}
+
+/// Torrent client configuration
+#[derive(Debug, Clone, Deserialize)]
+pub struct TorrentConfig {
+    #[serde(default = "default_download_dir")]
+    pub download_dir: PathBuf,
+    #[serde(default)]
+    pub bind_interface: String,
+    #[serde(default = "default_max_connections")]
+    pub max_connections: u32,
+    #[serde(default = "default_port_range")]
+    pub port_range: (u16, u16),
+    #[serde(default)]
+    pub seeding: SeedingConfig,
+}
+
+impl Default for TorrentConfig {
+    fn default() -> Self {
+        Self {
+            download_dir: default_download_dir(),
+            bind_interface: String::new(),
+            max_connections: default_max_connections(),
+            port_range: default_port_range(),
+            seeding: SeedingConfig::default(),
+        }
+    }
+}
+
+fn default_download_dir() -> PathBuf {
+    PathBuf::from("./downloads")
+}
+
+fn default_max_connections() -> u32 {
+    100
+}
+
+fn default_port_range() -> (u16, u16) {
+    (6881, 6889)
+}
+
+/// Seeding configuration
+#[derive(Debug, Clone, Deserialize)]
+pub struct SeedingConfig {
+    #[serde(default = "default_seeding_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_ratio_limit")]
+    pub ratio_limit: f64,
+    #[serde(default = "default_time_limit")]
+    pub time_limit_hours: u64,
+}
+
+impl Default for SeedingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_seeding_enabled(),
+            ratio_limit: default_ratio_limit(),
+            time_limit_hours: default_time_limit(),
+        }
+    }
+}
+
+fn default_seeding_enabled() -> bool {
+    true
+}
+
+fn default_ratio_limit() -> f64 {
+    1.0
+}
+
+fn default_time_limit() -> u64 {
+    48
+}
+
+/// Storage configuration
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct StorageConfig {
+    #[serde(default)]
+    pub mounts: Vec<MountConfig>,
+    #[serde(default)]
+    pub naming: NamingConfig,
+    #[serde(default)]
+    pub rules: Vec<StorageRule>,
+}
+
+/// Mount point configuration
+#[derive(Clone, Deserialize)]
+pub struct MountConfig {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub mount_type: MountType,
+    #[serde(default)]
+    pub path: Option<PathBuf>,
+    #[serde(default)]
+    pub host: Option<String>,
+    #[serde(default)]
+    pub share: Option<String>,
+    #[serde(default)]
+    pub username: Option<String>,
+    #[serde(default)]
+    pub password: Option<String>,
+    #[serde(default)]
+    pub mount_point: Option<PathBuf>,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+// Custom Debug implementation to avoid exposing password
+impl std::fmt::Debug for MountConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MountConfig")
+            .field("name", &self.name)
+            .field("mount_type", &self.mount_type)
+            .field("path", &self.path)
+            .field("host", &self.host)
+            .field("share", &self.share)
+            .field("username", &self.username)
+            .field("password", &self.password.as_ref().map(|_| "[REDACTED]"))
+            .field("mount_point", &self.mount_point)
+            .field("enabled", &self.enabled)
+            .finish()
+    }
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum MountType {
+    Local,
+    Smb,
+}
+
+/// File naming patterns
+#[derive(Debug, Clone, Deserialize)]
+pub struct NamingConfig {
+    #[serde(default = "default_movie_pattern")]
+    pub movie_pattern: String,
+    #[serde(default = "default_tv_pattern")]
+    pub tv_pattern: String,
+    #[serde(default = "default_music_pattern")]
+    pub music_pattern: String,
+}
+
+impl Default for NamingConfig {
+    fn default() -> Self {
+        Self {
+            movie_pattern: default_movie_pattern(),
+            tv_pattern: default_tv_pattern(),
+            music_pattern: default_music_pattern(),
+        }
+    }
+}
+
+fn default_movie_pattern() -> String {
+    "movie/{title} ({year})/{title} ({year}) - {quality}.{ext}".to_string()
+}
+
+fn default_tv_pattern() -> String {
+    "tv/{title}/S{season:02}/{title} - S{season:02}E{episode:02} - {episode_title}.{ext}"
+        .to_string()
+}
+
+fn default_music_pattern() -> String {
+    "music/{artist}/{album}/{title}.{ext}".to_string()
+}
+
+/// Storage rule for post-download processing
+#[derive(Debug, Clone, Deserialize)]
+pub struct StorageRule {
+    pub action: StorageAction,
+    pub destination: String,
+    #[serde(default)]
+    pub media_types: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum StorageAction {
+    Move,
+    Copy,
+}
+
+/// Scheduler configuration with cron expressions
+#[derive(Debug, Clone, Deserialize)]
+pub struct SchedulerConfig {
+    #[serde(default = "default_search_missing")]
+    pub search_missing: String,
+    #[serde(default = "default_refresh_metadata")]
+    pub refresh_metadata: String,
+    #[serde(default = "default_check_new_episodes")]
+    pub check_new_episodes: String,
+    #[serde(default = "default_check_new_releases")]
+    pub check_new_releases: String,
+    #[serde(default = "default_cleanup_completed")]
+    pub cleanup_completed: String,
+}
+
+impl Default for SchedulerConfig {
+    fn default() -> Self {
+        Self {
+            search_missing: default_search_missing(),
+            refresh_metadata: default_refresh_metadata(),
+            check_new_episodes: default_check_new_episodes(),
+            check_new_releases: default_check_new_releases(),
+            cleanup_completed: default_cleanup_completed(),
+        }
+    }
+}
+
+fn default_search_missing() -> String {
+    "0 0 */6 * * *".to_string()
+}
+
+fn default_refresh_metadata() -> String {
+    "0 0 2 * * *".to_string()
+}
+
+fn default_check_new_episodes() -> String {
+    "0 0 */12 * * *".to_string()
+}
+
+fn default_check_new_releases() -> String {
+    "0 0 3 * * *".to_string()
+}
+
+fn default_cleanup_completed() -> String {
+    "0 0 * * * *".to_string()
+}
+
+impl Config {
+    /// Load configuration from file and environment variables.
+    ///
+    /// Configuration is loaded in the following order (later sources override earlier):
+    /// 1. Default values
+    /// 2. `config.toml` in current directory (optional)
+    /// 3. Environment variables with `LCARS_` prefix
+    ///
+    /// Environment variables use double underscore for nesting:
+    /// - `LCARS_SERVER__PORT=9000` sets `server.port`
+    /// - `LCARS_DATABASE__PATH=/data/db.sqlite` sets `database.path`
+    pub fn load() -> Result<Self, AppError> {
+        Self::load_from("config.toml")
+    }
+
+    /// Load configuration from a specific file path.
+    pub fn load_from(config_path: &str) -> Result<Self, AppError> {
+        let config = ConfigLoader::builder()
+            // Start with defaults
+            .set_default("server.host", "0.0.0.0")?
+            .set_default("server.port", 8080)?
+            .set_default("database.path", "./data/lcars.db")?
+            .set_default("musicbrainz.rate_limit_ms", 1000)?
+            .set_default("torrent.download_dir", "./downloads")?
+            .set_default("torrent.max_connections", 100)?
+            .set_default("torrent.seeding.enabled", true)?
+            .set_default("torrent.seeding.ratio_limit", 1.0)?
+            .set_default("torrent.seeding.time_limit_hours", 48)?
+            // Add config file (optional)
+            .add_source(File::with_name(config_path).required(false))
+            // Override with environment variables
+            // LCARS_SERVER__PORT=9000 -> server.port = 9000
+            .add_source(
+                Environment::with_prefix("LCARS")
+                    .separator("__")
+                    .try_parsing(true),
+            )
+            .build()?;
+
+        let config: Config = config.try_deserialize()?;
+
+        // Validate required fields for certain operations
+        config.validate()?;
+
+        Ok(config)
+    }
+
+    /// Validate configuration for required fields.
+    fn validate(&self) -> Result<(), AppError> {
+        // JWT secret is required in production but we don't fail here
+        // since it might be set later or not needed for all operations
+        if self.server.jwt_secret.is_none() {
+            tracing::warn!("JWT secret not configured - authentication will not work");
+        }
+
+        if self.tmdb.api_key.is_none() {
+            tracing::warn!("TMDB API key not configured - movie/TV metadata lookups will fail");
+        }
+
+        Ok(())
+    }
+
+    /// Get the server socket address
+    pub fn server_addr(&self) -> std::net::SocketAddr {
+        use std::net::{IpAddr, SocketAddr};
+        let ip: IpAddr = self.server.host.parse().unwrap_or_else(|_| {
+            tracing::warn!("Invalid host '{}', using 0.0.0.0", self.server.host);
+            "0.0.0.0".parse().unwrap()
+        });
+        SocketAddr::new(ip, self.server.port)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = Config::load_from("nonexistent.toml").unwrap();
+        assert_eq!(config.server.port, 8080);
+        assert_eq!(config.server.host, "0.0.0.0");
+        assert_eq!(config.database.path, PathBuf::from("./data/lcars.db"));
+        assert_eq!(config.musicbrainz.rate_limit_ms, 1000);
+    }
+
+    #[test]
+    fn test_server_addr() {
+        let config = Config::load_from("nonexistent.toml").unwrap();
+        let addr = config.server_addr();
+        assert_eq!(addr.port(), 8080);
+    }
+
+    #[test]
+    fn test_torrent_defaults() {
+        let config = Config::load_from("nonexistent.toml").unwrap();
+        assert_eq!(config.torrent.max_connections, 100);
+        assert!(config.torrent.seeding.enabled);
+        assert_eq!(config.torrent.seeding.ratio_limit, 1.0);
+        assert_eq!(config.torrent.seeding.time_limit_hours, 48);
+    }
+}

--- a/apps/backend/src/db/mod.rs
+++ b/apps/backend/src/db/mod.rs
@@ -6,6 +6,7 @@
 
 use rusqlite::Connection;
 use std::path::Path;
+use thiserror::Error;
 
 pub mod models;
 pub mod queries;
@@ -15,33 +16,13 @@ mod embedded {
     embed_migrations!("src/db/migrations");
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum DbError {
-    Connection(rusqlite::Error),
-    Migration(refinery::Error),
-}
+    #[error("Database connection error: {0}")]
+    Connection(#[from] rusqlite::Error),
 
-impl std::fmt::Display for DbError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            DbError::Connection(e) => write!(f, "Database connection error: {}", e),
-            DbError::Migration(e) => write!(f, "Migration error: {}", e),
-        }
-    }
-}
-
-impl std::error::Error for DbError {}
-
-impl From<rusqlite::Error> for DbError {
-    fn from(err: rusqlite::Error) -> Self {
-        DbError::Connection(err)
-    }
-}
-
-impl From<refinery::Error> for DbError {
-    fn from(err: refinery::Error) -> Self {
-        DbError::Migration(err)
-    }
+    #[error("Migration error: {0}")]
+    Migration(#[from] refinery::Error),
 }
 
 /// Configure connection with recommended pragmas

--- a/apps/backend/src/error.rs
+++ b/apps/backend/src/error.rs
@@ -1,0 +1,154 @@
+//! Application error types for the LCARS backend.
+//!
+//! Provides a unified error type that implements `IntoResponse` for Axum.
+
+#![allow(dead_code)]
+
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::db::DbError;
+
+/// Application-wide error type
+#[derive(Error, Debug)]
+pub enum AppError {
+    /// Database-related errors
+    #[error("Database error: {0}")]
+    Database(#[from] DbError),
+
+    /// SQLite-specific errors (for direct rusqlite usage)
+    #[error("Database error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+
+    /// Configuration loading/parsing errors
+    #[error("Configuration error: {0}")]
+    Config(#[from] config::ConfigError),
+
+    /// Resource not found
+    #[error("Not found: {0}")]
+    NotFound(String),
+
+    /// Authentication required
+    #[error("Unauthorized")]
+    Unauthorized,
+
+    /// Insufficient permissions
+    #[error("Forbidden")]
+    Forbidden,
+
+    /// Invalid request data
+    #[error("Bad request: {0}")]
+    BadRequest(String),
+
+    /// Internal server error
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+/// JSON error response body
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let (status, error, message) = match &self {
+            AppError::Database(e) => {
+                // Log full error details but don't expose to client
+                tracing::error!("Database error: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "database_error",
+                    None, // Don't expose internal DB errors to clients
+                )
+            }
+            AppError::Sqlite(e) => {
+                // Log full error details but don't expose to client
+                tracing::error!("SQLite error: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "database_error",
+                    None, // Don't expose internal DB errors to clients
+                )
+            }
+            AppError::Config(e) => {
+                // Log full error details but don't expose to client
+                tracing::error!("Config error: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "configuration_error",
+                    None, // Don't expose config errors to clients
+                )
+            }
+            AppError::NotFound(resource) => {
+                (StatusCode::NOT_FOUND, "not_found", Some(resource.clone()))
+            }
+            AppError::Unauthorized => (StatusCode::UNAUTHORIZED, "unauthorized", None),
+            AppError::Forbidden => (StatusCode::FORBIDDEN, "forbidden", None),
+            AppError::BadRequest(msg) => {
+                // Bad request messages are safe to expose (client-caused errors)
+                (StatusCode::BAD_REQUEST, "bad_request", Some(msg.clone()))
+            }
+            AppError::Internal(msg) => {
+                // Log full error but don't expose internal details
+                tracing::error!("Internal error: {}", msg);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal_error",
+                    None, // Don't expose internal errors to clients
+                )
+            }
+        };
+
+        let body = ErrorResponse {
+            error: error.to_string(),
+            message,
+        };
+
+        (status, Json(body)).into_response()
+    }
+}
+
+/// Result type alias for handlers
+pub type Result<T> = std::result::Result<T, AppError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_not_found_status() {
+        let error = AppError::NotFound("test".to_string());
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn test_unauthorized_status() {
+        let error = AppError::Unauthorized;
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn test_bad_request_status() {
+        let error = AppError::BadRequest("invalid".to_string());
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn test_forbidden_status() {
+        let error = AppError::Forbidden;
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+}

--- a/apps/backend/src/main.rs
+++ b/apps/backend/src/main.rs
@@ -1,8 +1,22 @@
 use axum::{response::Json, routing::get, Router};
+use rusqlite::Connection;
 use serde::Serialize;
-use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
+mod config;
 mod db;
+mod error;
+
+use config::Config;
+
+/// Application state shared across handlers
+#[derive(Clone)]
+pub struct AppState {
+    pub config: Arc<Config>,
+    pub db: Arc<Mutex<Connection>>,
+}
 
 #[derive(Serialize)]
 struct ApiResponse {
@@ -17,12 +31,75 @@ async fn health_check() -> Json<ApiResponse> {
     })
 }
 
+fn init_tracing() {
+    // Initialize tracing with env-filter
+    // RUST_LOG environment variable controls log levels
+    // Default: debug for our crate, info for axum, warn for dependencies
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("backend=debug,tower_http=debug,axum=info,warn"));
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+}
+
 #[tokio::main]
 async fn main() {
-    let app = Router::new().route("/health", get(health_check));
+    // Initialize tracing first so we can log configuration loading
+    init_tracing();
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], 3001));
-    println!("🚀 LCARS Backend listening on {}", addr);
+    tracing::info!("Starting LCARS Backend v{}", env!("CARGO_PKG_VERSION"));
+
+    // Load configuration
+    let config = match Config::load() {
+        Ok(cfg) => {
+            tracing::info!("Configuration loaded successfully");
+            tracing::debug!("Server: {}:{}", cfg.server.host, cfg.server.port);
+            tracing::debug!("Database: {:?}", cfg.database.path);
+            cfg
+        }
+        Err(e) => {
+            tracing::error!("Failed to load configuration: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    // Ensure database directory exists
+    if let Some(parent) = config.database.path.parent() {
+        if !parent.exists() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                tracing::error!("Failed to create database directory: {}", e);
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // Initialize database
+    let conn = match db::init_db(&config.database.path) {
+        Ok(conn) => {
+            tracing::info!("Database initialized at {:?}", config.database.path);
+            conn
+        }
+        Err(e) => {
+            tracing::error!("Failed to initialize database: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    // Create application state
+    let state = AppState {
+        config: Arc::new(config.clone()),
+        db: Arc::new(Mutex::new(conn)),
+    };
+
+    // Build router with state
+    let app = Router::new()
+        .route("/health", get(health_check))
+        .with_state(state);
+
+    let addr = config.server_addr();
+    tracing::info!("LCARS Backend listening on {}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,102 @@
+# LCARS Configuration Example
+# Copy this file to config.toml and customize for your environment.
+# All values shown are defaults unless marked as required.
+
+[server]
+# Host address to bind to (default: "0.0.0.0")
+host = "0.0.0.0"
+# Port to listen on (default: 8080)
+port = 8080
+# JWT secret for authentication (REQUIRED for auth to work)
+# Generate with: openssl rand -base64 32
+jwt_secret = "change-me-generate-a-secure-random-string"
+
+[database]
+# Path to SQLite database file (default: "./data/lcars.db")
+path = "./data/lcars.db"
+
+[tmdb]
+# TMDB API key for movie/TV metadata (REQUIRED for media lookups)
+# Get one at: https://www.themoviedb.org/settings/api
+api_key = "your-tmdb-api-key"
+
+[musicbrainz]
+# Rate limit in milliseconds (default: 1000)
+# MusicBrainz API requires max 1 request per second
+rate_limit_ms = 1000
+
+[torrent]
+# Directory for active downloads (default: "./downloads")
+download_dir = "./downloads"
+# VPN interface to bind torrent traffic to (empty for default interface)
+bind_interface = ""
+# Maximum concurrent connections (default: 100)
+max_connections = 100
+# Port range for incoming connections (default: [6881, 6889])
+port_range = [6881, 6889]
+
+[torrent.seeding]
+# Enable seeding after download (default: true)
+enabled = true
+# Stop seeding after reaching this ratio (default: 1.0)
+ratio_limit = 1.0
+# Stop seeding after this many hours (default: 48)
+time_limit_hours = 48
+
+# Storage mount points
+# Multiple mounts can be configured for different destinations
+
+[[storage.mounts]]
+name = "local"
+type = "local"
+path = "/media/library"
+enabled = true
+
+# Example SMB mount (disabled by default)
+# [[storage.mounts]]
+# name = "nas"
+# type = "smb"
+# host = "192.168.1.100"
+# share = "media"
+# username = "user"
+# password = "pass"
+# mount_point = "/mnt/nas"
+# enabled = false
+
+[storage.naming]
+# File naming patterns with placeholders
+# Movie: {title}, {year}, {quality}, {source}, {codec}, {group}, {ext}
+movie_pattern = "movie/{title} ({year})/{title} ({year}) - {quality}.{ext}"
+# TV: {title}, {season:02}, {episode:02}, {episode_title}, {quality}, {ext}
+tv_pattern = "tv/{title}/S{season:02}/{title} - S{season:02}E{episode:02} - {episode_title}.{ext}"
+# Music: {artist}, {album}, {title}, {track:02}, {disc:02}, {format}, {ext}
+music_pattern = "music/{artist}/{album}/{title}.{ext}"
+
+# Storage rules for post-download processing
+# Rules are processed in order
+
+[[storage.rules]]
+action = "move"
+destination = "local"
+media_types = ["movie", "episode", "album"]
+
+# Example: Copy movies to NAS as backup
+# [[storage.rules]]
+# action = "copy"
+# destination = "nas"
+# media_types = ["movie"]
+
+[scheduler]
+# Cron expressions for scheduled tasks
+# Format: second minute hour day_of_month month day_of_week
+
+# Search for missing monitored media (default: every 6 hours)
+search_missing = "0 0 */6 * * *"
+# Refresh metadata from TMDB/MusicBrainz (default: 2 AM daily)
+refresh_metadata = "0 0 2 * * *"
+# Check for new episodes (default: every 12 hours)
+check_new_episodes = "0 0 */12 * * *"
+# Check for new album releases (default: 3 AM daily)
+check_new_releases = "0 0 3 * * *"
+# Clean up completed downloads (default: hourly)
+cleanup_completed = "0 0 * * * *"


### PR DESCRIPTION
## Summary

- Add configuration loading from TOML files with environment variable overrides
- Create unified error handling system with proper HTTP status codes
- Initialize tracing with env-filter for log level control
- Create documented example configuration file

## Changes

- **Cargo.toml**: Added `config`, `thiserror`, `tracing`, `tracing-subscriber` dependencies
- **src/config.rs**: Configuration structs and loading logic (TOML + env vars)
- **src/error.rs**: AppError enum with IntoResponse for Axum
- **src/main.rs**: Tracing init, config loading, AppState with db connection
- **src/db/mod.rs**: Converted DbError to use thiserror
- **config.example.toml**: Documented example configuration

## Security

- Secrets (jwt_secret, api_key, password) are redacted in Debug output
- Internal error details are logged but not exposed to API clients

## Test plan

- [x] All existing tests pass
- [x] `moon ci` passes (fmt-check, clippy, test, check, build)
- [x] Config loads from TOML file
- [x] Environment variables override config (LCARS_SERVER__PORT, etc.)
- [x] Missing config uses sensible defaults
- [x] Tracing logs appear with appropriate levels

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)