### PR TITLE
feat(backend): add Downloads API and WebSocket for real-time updates

### DIFF
--- a/apps/backend/Cargo.toml
+++ b/apps/backend/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1.35", features = ["full"] }
-axum = "0.7"
+axum = { version = "0.7", features = ["ws"] }
 tower = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/apps/backend/src/api/downloads.rs
+++ b/apps/backend/src/api/downloads.rs
@@ -1,0 +1,528 @@
+//! Downloads API endpoints for managing active downloads.
+
+use axum::{
+    extract::{Path, Query, State},
+    middleware as axum_mw,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::db::models::{Download, DownloadStatus, MediaType};
+use crate::error::{AppError, Result};
+use crate::middleware;
+use crate::services::torrent::MediaRef;
+use crate::AppState;
+
+// =============================================================================
+// Request/Response Types
+// =============================================================================
+
+/// Query parameters for listing downloads.
+#[derive(Debug, Deserialize)]
+pub struct ListDownloadsQuery {
+    /// Filter by status (queued, downloading, seeding, processing, completed, failed, paused).
+    pub status: Option<String>,
+}
+
+/// Query parameters for deleting a download.
+#[derive(Debug, Deserialize)]
+pub struct DeleteDownloadQuery {
+    /// Whether to delete downloaded files (default: false).
+    pub delete_files: Option<bool>,
+}
+
+/// Success response for operations without specific data.
+#[derive(Debug, Serialize)]
+pub struct SuccessResponse {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+// =============================================================================
+// Router
+// =============================================================================
+
+/// Creates the downloads router with all endpoints.
+pub fn router(state: AppState) -> Router<AppState> {
+    Router::new()
+        .route("/", get(list_downloads))
+        .route("/{id}", get(get_download).delete(delete_download))
+        .route("/{id}/pause", post(pause_download))
+        .route("/{id}/resume", post(resume_download))
+        .route("/{id}/retry", post(retry_download))
+        .layer(axum_mw::from_fn_with_state(
+            state,
+            middleware::auth_middleware,
+        ))
+}
+
+// =============================================================================
+// Handlers
+// =============================================================================
+
+/// GET /api/downloads
+///
+/// Lists all downloads with optional status filtering.
+/// Merges database records with real-time stats from the torrent engine.
+pub async fn list_downloads(
+    State(state): State<AppState>,
+    Query(query): Query<ListDownloadsQuery>,
+) -> Result<Json<Vec<Download>>> {
+    // Validate status filter if provided
+    if let Some(ref status) = query.status {
+        let valid_statuses = [
+            "queued",
+            "downloading",
+            "seeding",
+            "processing",
+            "completed",
+            "failed",
+            "paused",
+        ];
+        if !valid_statuses.contains(&status.as_str()) {
+            return Err(AppError::BadRequest(format!("Invalid status: {}", status)));
+        }
+    }
+
+    let mut downloads: Vec<Download> = {
+        let db = state.db.lock().await;
+
+        // Query downloads from database
+        let mut stmt = db.prepare(
+            r#"
+            SELECT id, info_hash, name, media_type, media_id, magnet, status,
+                   progress, download_speed, upload_speed, size_bytes,
+                   downloaded_bytes, uploaded_bytes, ratio, peers, error_message,
+                   added_at, started_at, completed_at
+            FROM downloads
+            WHERE (?1 IS NULL OR status = ?1)
+            ORDER BY added_at DESC
+            "#,
+        )?;
+
+        let downloads = stmt
+            .query_map(rusqlite::params![query.status], map_download_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        downloads
+    };
+
+    // Merge with real-time stats from torrent engine if available
+    if let Some(torrent_engine) = state.torrent_engine() {
+        let live_stats = torrent_engine.list_all().await;
+
+        for download in &mut downloads {
+            if let Some(stats) = live_stats
+                .iter()
+                .find(|s| s.info_hash == download.info_hash)
+            {
+                download.progress = stats.progress;
+                download.download_speed = stats.download_speed as i64;
+                download.upload_speed = stats.upload_speed as i64;
+                download.downloaded_bytes = stats.downloaded as i64;
+                download.uploaded_bytes = stats.uploaded as i64;
+                download.ratio = stats.ratio;
+                download.peers = stats.peers as i32;
+                download.size_bytes = Some(stats.size as i64);
+            }
+        }
+    }
+
+    Ok(Json(downloads))
+}
+
+/// GET /api/downloads/:id
+///
+/// Gets a single download by ID with real-time stats.
+pub async fn get_download(
+    State(state): State<AppState>,
+    Path(download_id): Path<i64>,
+) -> Result<Json<Download>> {
+    let db = state.db.lock().await;
+
+    let mut download = db
+        .query_row(
+            r#"
+            SELECT id, info_hash, name, media_type, media_id, magnet, status,
+                   progress, download_speed, upload_speed, size_bytes,
+                   downloaded_bytes, uploaded_bytes, ratio, peers, error_message,
+                   added_at, started_at, completed_at
+            FROM downloads WHERE id = ?1
+            "#,
+            [download_id],
+            map_download_row,
+        )
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => {
+                AppError::NotFound("Download not found".to_string())
+            }
+            _ => AppError::Sqlite(e),
+        })?;
+
+    drop(db); // Release lock before accessing torrent engine
+
+    // Merge with real-time stats from torrent engine if available
+    if let Some(torrent_engine) = state.torrent_engine() {
+        if let Ok(stats) = torrent_engine.get_status(&download.info_hash).await {
+            download.progress = stats.progress;
+            download.download_speed = stats.download_speed as i64;
+            download.upload_speed = stats.upload_speed as i64;
+            download.downloaded_bytes = stats.downloaded as i64;
+            download.uploaded_bytes = stats.uploaded as i64;
+            download.ratio = stats.ratio;
+            download.peers = stats.peers as i32;
+            download.size_bytes = Some(stats.size as i64);
+        }
+    }
+
+    Ok(Json(download))
+}
+
+/// DELETE /api/downloads/:id
+///
+/// Removes a download from the torrent engine and database.
+pub async fn delete_download(
+    State(state): State<AppState>,
+    Path(download_id): Path<i64>,
+    Query(query): Query<DeleteDownloadQuery>,
+) -> Result<Json<SuccessResponse>> {
+    let db = state.db.lock().await;
+
+    // Get download info
+    let (info_hash, media_type_str, media_id): (String, String, i64) = db
+        .query_row(
+            "SELECT info_hash, media_type, media_id FROM downloads WHERE id = ?1",
+            [download_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => {
+                AppError::NotFound("Download not found".to_string())
+            }
+            _ => AppError::Sqlite(e),
+        })?;
+
+    // Parse and validate media type
+    let media_type = match media_type_str.as_str() {
+        "movie" => MediaType::Movie,
+        "episode" => MediaType::Episode,
+        "album" => MediaType::Album,
+        "track" => MediaType::Track,
+        _ => {
+            return Err(AppError::Internal(format!(
+                "Invalid media type in database: {}",
+                media_type_str
+            )))
+        }
+    };
+
+    drop(db); // Release lock before async operations
+
+    // Remove from torrent engine
+    let delete_files = query.delete_files.unwrap_or(false);
+    if let Some(torrent_engine) = state.torrent_engine() {
+        if let Err(e) = torrent_engine.remove(&info_hash, delete_files).await {
+            tracing::debug!(
+                info_hash = %info_hash,
+                error = %e,
+                "Failed to remove torrent from engine (may have already been removed)"
+            );
+        }
+    }
+
+    // Delete from database and revert media status
+    let db = state.db.lock().await;
+
+    db.execute("DELETE FROM downloads WHERE id = ?1", [download_id])?;
+
+    // Revert media status to 'missing'
+    let update_query = match media_type {
+        MediaType::Movie => {
+            "UPDATE movies SET status = 'missing', updated_at = datetime('now') WHERE id = ?1"
+        }
+        MediaType::Episode => {
+            "UPDATE episodes SET status = 'missing', updated_at = datetime('now') WHERE id = ?1"
+        }
+        MediaType::Album => {
+            "UPDATE albums SET status = 'missing', updated_at = datetime('now') WHERE id = ?1"
+        }
+        MediaType::Track => {
+            "UPDATE tracks SET status = 'missing', updated_at = datetime('now') WHERE id = ?1"
+        }
+    };
+
+    db.execute(update_query, [media_id])?;
+
+    tracing::info!(
+        download_id = download_id,
+        info_hash = %info_hash,
+        delete_files = delete_files,
+        "Download deleted"
+    );
+
+    Ok(Json(SuccessResponse {
+        success: true,
+        message: Some("Download deleted successfully".to_string()),
+    }))
+}
+
+/// POST /api/downloads/:id/pause
+///
+/// Pauses a download.
+pub async fn pause_download(
+    State(state): State<AppState>,
+    Path(download_id): Path<i64>,
+) -> Result<Json<Download>> {
+    let db = state.db.lock().await;
+
+    // Get download info
+    let (info_hash,): (String,) = db
+        .query_row(
+            "SELECT info_hash FROM downloads WHERE id = ?1",
+            [download_id],
+            |row| Ok((row.get(0)?,)),
+        )
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => {
+                AppError::NotFound("Download not found".to_string())
+            }
+            _ => AppError::Sqlite(e),
+        })?;
+
+    drop(db); // Release lock before async operations
+
+    // Pause in torrent engine
+    let torrent_engine = state
+        .torrent_engine()
+        .ok_or_else(|| AppError::Internal("Torrent engine not available".to_string()))?;
+
+    torrent_engine.pause(&info_hash).await?;
+
+    // Update database status
+    let db = state.db.lock().await;
+    db.execute(
+        "UPDATE downloads SET status = 'paused' WHERE id = ?1",
+        [download_id],
+    )?;
+
+    // Fetch updated download
+    let download = db.query_row(
+        r#"
+        SELECT id, info_hash, name, media_type, media_id, magnet, status,
+               progress, download_speed, upload_speed, size_bytes,
+               downloaded_bytes, uploaded_bytes, ratio, peers, error_message,
+               added_at, started_at, completed_at
+        FROM downloads WHERE id = ?1
+        "#,
+        [download_id],
+        map_download_row,
+    )?;
+
+    tracing::info!(
+        download_id = download_id,
+        info_hash = %info_hash,
+        "Download paused"
+    );
+
+    Ok(Json(download))
+}
+
+/// POST /api/downloads/:id/resume
+///
+/// Resumes a paused download.
+pub async fn resume_download(
+    State(state): State<AppState>,
+    Path(download_id): Path<i64>,
+) -> Result<Json<Download>> {
+    let db = state.db.lock().await;
+
+    // Get download info
+    let (info_hash,): (String,) = db
+        .query_row(
+            "SELECT info_hash FROM downloads WHERE id = ?1",
+            [download_id],
+            |row| Ok((row.get(0)?,)),
+        )
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => {
+                AppError::NotFound("Download not found".to_string())
+            }
+            _ => AppError::Sqlite(e),
+        })?;
+
+    drop(db); // Release lock before async operations
+
+    // Resume in torrent engine
+    let torrent_engine = state
+        .torrent_engine()
+        .ok_or_else(|| AppError::Internal("Torrent engine not available".to_string()))?;
+
+    torrent_engine.resume(&info_hash).await?;
+
+    // Update database status
+    let db = state.db.lock().await;
+    db.execute(
+        "UPDATE downloads SET status = 'downloading' WHERE id = ?1",
+        [download_id],
+    )?;
+
+    // Fetch updated download
+    let download = db.query_row(
+        r#"
+        SELECT id, info_hash, name, media_type, media_id, magnet, status,
+               progress, download_speed, upload_speed, size_bytes,
+               downloaded_bytes, uploaded_bytes, ratio, peers, error_message,
+               added_at, started_at, completed_at
+        FROM downloads WHERE id = ?1
+        "#,
+        [download_id],
+        map_download_row,
+    )?;
+
+    tracing::info!(
+        download_id = download_id,
+        info_hash = %info_hash,
+        "Download resumed"
+    );
+
+    Ok(Json(download))
+}
+
+/// POST /api/downloads/:id/retry
+///
+/// Retries a failed download by re-adding the magnet link.
+pub async fn retry_download(
+    State(state): State<AppState>,
+    Path(download_id): Path<i64>,
+) -> Result<Json<Download>> {
+    let db = state.db.lock().await;
+
+    // Get download info
+    let (info_hash, magnet, media_type_str, media_id): (String, String, String, i64) = db
+        .query_row(
+            "SELECT info_hash, magnet, media_type, media_id FROM downloads WHERE id = ?1",
+            [download_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => {
+                AppError::NotFound("Download not found".to_string())
+            }
+            _ => AppError::Sqlite(e),
+        })?;
+
+    drop(db); // Release lock before async operations
+
+    // Get torrent engine
+    let torrent_engine = state
+        .torrent_engine()
+        .ok_or_else(|| AppError::Internal("Torrent engine not available".to_string()))?;
+
+    // Remove the failed torrent if it exists
+    let _ = torrent_engine.remove(&info_hash, false).await;
+
+    // Parse media type
+    let media_type = match media_type_str.as_str() {
+        "movie" => MediaType::Movie,
+        "episode" => MediaType::Episode,
+        "album" => MediaType::Album,
+        "track" => MediaType::Track,
+        _ => return Err(AppError::Internal("Invalid media type".to_string())),
+    };
+
+    // Re-add the magnet
+    let media_ref = MediaRef {
+        media_type,
+        media_id,
+    };
+
+    let new_info_hash = torrent_engine.add_magnet(&magnet, media_ref).await?;
+
+    // Update database
+    let db = state.db.lock().await;
+
+    db.execute(
+        r#"
+        UPDATE downloads
+        SET info_hash = ?1, status = 'downloading', error_message = NULL,
+            progress = 0, download_speed = 0, upload_speed = 0,
+            downloaded_bytes = 0, uploaded_bytes = 0, ratio = 0, peers = 0,
+            started_at = datetime('now')
+        WHERE id = ?2
+        "#,
+        rusqlite::params![new_info_hash, download_id],
+    )?;
+
+    // Fetch updated download
+    let download = db.query_row(
+        r#"
+        SELECT id, info_hash, name, media_type, media_id, magnet, status,
+               progress, download_speed, upload_speed, size_bytes,
+               downloaded_bytes, uploaded_bytes, ratio, peers, error_message,
+               added_at, started_at, completed_at
+        FROM downloads WHERE id = ?1
+        "#,
+        [download_id],
+        map_download_row,
+    )?;
+
+    tracing::info!(
+        download_id = download_id,
+        old_info_hash = %info_hash,
+        new_info_hash = %new_info_hash,
+        "Download retried"
+    );
+
+    Ok(Json(download))
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Maps a database row to a Download struct.
+fn map_download_row(row: &rusqlite::Row) -> rusqlite::Result<Download> {
+    let status_str: String = row.get(6)?;
+    let status = match status_str.as_str() {
+        "queued" => DownloadStatus::Queued,
+        "downloading" => DownloadStatus::Downloading,
+        "seeding" => DownloadStatus::Seeding,
+        "processing" => DownloadStatus::Processing,
+        "completed" => DownloadStatus::Completed,
+        "failed" => DownloadStatus::Failed,
+        "paused" => DownloadStatus::Paused,
+        _ => DownloadStatus::Queued,
+    };
+
+    let media_type_str: String = row.get(3)?;
+    let media_type = match media_type_str.as_str() {
+        "movie" => MediaType::Movie,
+        "episode" => MediaType::Episode,
+        "album" => MediaType::Album,
+        "track" => MediaType::Track,
+        _ => MediaType::Movie,
+    };
+
+    Ok(Download {
+        id: row.get(0)?,
+        info_hash: row.get(1)?,
+        name: row.get(2)?,
+        media_type,
+        media_id: row.get(4)?,
+        magnet: row.get(5)?,
+        status,
+        progress: row.get(7)?,
+        download_speed: row.get(8)?,
+        upload_speed: row.get(9)?,
+        size_bytes: row.get(10)?,
+        downloaded_bytes: row.get(11)?,
+        uploaded_bytes: row.get(12)?,
+        ratio: row.get(13)?,
+        peers: row.get(14)?,
+        error_message: row.get(15)?,
+        added_at: row.get(16)?,
+        started_at: row.get(17)?,
+        completed_at: row.get(18)?,
+    })
+}

--- a/apps/backend/src/api/mod.rs
+++ b/apps/backend/src/api/mod.rs
@@ -1,9 +1,11 @@
 //! API endpoint handlers for the LCARS backend.
 
 pub mod auth;
+pub mod downloads;
 pub mod movies;
 pub mod music;
 pub mod search;
 pub mod system;
 pub mod tv;
 pub mod users;
+pub mod ws;

--- a/apps/backend/src/api/ws.rs
+++ b/apps/backend/src/api/ws.rs
@@ -1,0 +1,230 @@
+//! WebSocket API endpoint for real-time download progress updates.
+
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        Query, State,
+    },
+    response::Response,
+};
+use futures::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+use crate::error::Result;
+use crate::services::torrent::TorrentEvent;
+use crate::AppState;
+
+// =============================================================================
+// Request/Response Types
+// =============================================================================
+
+/// Query parameters for WebSocket connection.
+///
+/// # Security Note
+/// The token is passed as a query parameter due to WebSocket limitations
+/// (browsers don't support custom headers in WebSocket handshake).
+/// Tokens may be exposed in server logs or browser history.
+/// Consider using short-lived tokens for WebSocket connections.
+#[derive(Debug, Deserialize)]
+pub struct WsQuery {
+    /// JWT token for authentication.
+    pub token: String,
+}
+
+/// WebSocket message sent to clients.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", content = "data", rename_all = "snake_case")]
+pub enum WsMessage {
+    /// A new download was added.
+    DownloadAdded { info_hash: String, name: String },
+
+    /// Download progress update.
+    DownloadProgress {
+        info_hash: String,
+        progress: f64,
+        download_speed: u64,
+        upload_speed: u64,
+        peers: usize,
+    },
+
+    /// Download completed.
+    DownloadCompleted { info_hash: String },
+
+    /// Download status changed.
+    DownloadStatus {
+        info_hash: String,
+        status: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error_message: Option<String>,
+    },
+
+    /// Download was removed.
+    DownloadRemoved { info_hash: String },
+
+    /// System status update (reserved for future use).
+    #[allow(dead_code)]
+    SystemStatus { active_downloads: usize },
+
+    /// Error message.
+    Error { message: String },
+}
+
+// =============================================================================
+// Handler
+// =============================================================================
+
+/// GET /api/ws
+///
+/// WebSocket endpoint for real-time updates.
+/// Requires authentication via `?token=<jwt>` query parameter.
+pub async fn ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+    Query(query): Query<WsQuery>,
+) -> Result<Response> {
+    // Validate JWT token
+    let _claims = state.auth_service().verify_token(&query.token)?;
+
+    tracing::debug!("WebSocket connection authenticated");
+
+    Ok(ws.on_upgrade(move |socket| handle_socket(socket, state)))
+}
+
+/// Handles an individual WebSocket connection.
+async fn handle_socket(socket: WebSocket, state: AppState) {
+    let (mut sender, mut receiver) = socket.split();
+
+    // Get torrent engine for event subscription
+    let torrent_engine = match state.torrent_engine() {
+        Some(engine) => engine,
+        None => {
+            // Send error and close if no torrent engine
+            let error_msg = WsMessage::Error {
+                message: "Torrent engine not available".to_string(),
+            };
+            if let Ok(json) = serde_json::to_string(&error_msg) {
+                let _ = sender.send(Message::Text(json)).await;
+            }
+            let _ = sender.close().await;
+            tracing::warn!("WebSocket closed: torrent engine not available");
+            return;
+        }
+    };
+
+    // Subscribe to torrent events
+    let mut event_rx = torrent_engine.subscribe();
+
+    tracing::info!("WebSocket client connected");
+
+    loop {
+        tokio::select! {
+            // Forward torrent events to WebSocket client
+            event = event_rx.recv() => {
+                match event {
+                    Ok(torrent_event) => {
+                        let ws_msg = convert_torrent_event(torrent_event);
+                        match serde_json::to_string(&ws_msg) {
+                            Ok(json) => {
+                                if sender.send(Message::Text(json)).await.is_err() {
+                                    tracing::debug!("WebSocket send failed, closing connection");
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                tracing::error!("Failed to serialize WebSocket message: {}", e);
+                            }
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(count)) => {
+                        tracing::warn!("WebSocket client lagged, missed {} events", count);
+                        // Continue receiving - don't disconnect for lag
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        tracing::debug!("Event channel closed, closing WebSocket");
+                        break;
+                    }
+                }
+            }
+
+            // Handle incoming messages from client
+            msg = receiver.next() => {
+                match msg {
+                    Some(Ok(Message::Ping(data))) => {
+                        if sender.send(Message::Pong(data)).await.is_err() {
+                            tracing::debug!("WebSocket pong failed, closing connection");
+                            break;
+                        }
+                    }
+                    Some(Ok(Message::Pong(_))) => {
+                        // Pong received, connection is alive
+                    }
+                    Some(Ok(Message::Close(_))) => {
+                        tracing::debug!("WebSocket client sent close");
+                        break;
+                    }
+                    Some(Ok(Message::Text(_))) => {
+                        // Client messages are currently ignored
+                        // Could be extended to support client commands
+                    }
+                    Some(Ok(Message::Binary(_))) => {
+                        // Binary messages not supported
+                    }
+                    Some(Err(e)) => {
+                        tracing::debug!("WebSocket error: {}", e);
+                        break;
+                    }
+                    None => {
+                        tracing::debug!("WebSocket stream ended");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    tracing::info!("WebSocket client disconnected");
+}
+
+/// Converts a TorrentEvent to a WebSocket message.
+fn convert_torrent_event(event: TorrentEvent) -> WsMessage {
+    match event {
+        TorrentEvent::Added { info_hash, name } => WsMessage::DownloadAdded { info_hash, name },
+
+        TorrentEvent::Progress {
+            info_hash,
+            progress,
+            download_speed,
+            upload_speed,
+            peers,
+        } => WsMessage::DownloadProgress {
+            info_hash,
+            progress,
+            download_speed,
+            upload_speed,
+            peers,
+        },
+
+        TorrentEvent::Completed { info_hash } => WsMessage::DownloadCompleted { info_hash },
+
+        TorrentEvent::Error { info_hash, message } => WsMessage::DownloadStatus {
+            info_hash,
+            status: "failed".to_string(),
+            error_message: Some(message),
+        },
+
+        TorrentEvent::Removed { info_hash } => WsMessage::DownloadRemoved { info_hash },
+
+        TorrentEvent::Paused { info_hash } => WsMessage::DownloadStatus {
+            info_hash,
+            status: "paused".to_string(),
+            error_message: None,
+        },
+
+        TorrentEvent::Resumed { info_hash } => WsMessage::DownloadStatus {
+            info_hash,
+            status: "downloading".to_string(),
+            error_message: None,
+        },
+    }
+}

--- a/apps/backend/src/main.rs
+++ b/apps/backend/src/main.rs
@@ -396,6 +396,9 @@ async fn main() {
     // Build music routes (authenticated)
     let music_routes = api::music::router(state.clone());
 
+    // Build downloads routes (authenticated)
+    let downloads_routes = api::downloads::router(state.clone());
+
     // Build search routes (authenticated)
     let search_routes = Router::new()
         .route("/musicbrainz/artists", get(api::search::search_mb_artists))
@@ -413,8 +416,10 @@ async fn main() {
         .nest("/api/movies", movies_routes)
         .nest("/api/tv", tv_routes)
         .nest("/api/music", music_routes)
+        .nest("/api/downloads", downloads_routes)
         .nest("/api/search", search_routes)
         .nest("/api/system", system_routes)
+        .route("/api/ws", get(api::ws::ws_handler))
         .with_state(state);
 
     let addr = config.server_addr();


### PR DESCRIPTION
## Summary
Implements issue #14: Downloads API and WebSocket for real-time progress updates.

**Downloads API Endpoints:**
- `GET /api/downloads` - List downloads with optional status filtering
- `GET /api/downloads/:id` - Get single download with real-time stats from torrent engine
- `DELETE /api/downloads/:id` - Remove download (optionally delete files)
- `POST /api/downloads/:id/pause` - Pause active download
- `POST /api/downloads/:id/resume` - Resume paused download
- `POST /api/downloads/:id/retry` - Retry failed download

**WebSocket Handler:**
- `GET /api/ws?token=<jwt>` - Real-time updates connection
- Forwards `TorrentEvent` from broadcast channel to connected clients
- Message types: `download:added`, `download:progress`, `download:completed`, `download:status`, `download:removed`, `error`

**Key Implementation Details:**
- Downloads API merges database records with live torrent engine statistics
- WebSocket authenticates via JWT query parameter (with security documentation)
- Proper validation of status filter parameter
- Follows existing patterns from movies/tv/music APIs
- Uses MediaType enum for type-safe media type handling

## Test plan
- [ ] Verify `moon ci` passes (format, clippy, tests, build)
- [ ] Test Downloads API endpoints manually
- [ ] Test WebSocket connection with `websocat ws://localhost:3001/api/ws?token=<jwt>`
- [ ] Verify pause/resume/retry operations work correctly

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)