### PR TITLE
feat(frontend): implement LCARS design system and base components

### DIFF
--- a/apps/frontend/bun.lock
+++ b/apps/frontend/bun.lock
@@ -5,9 +5,12 @@
     "": {
       "name": "frontend",
       "dependencies": {
+        "clsx": "^2.0.0",
+        "lucide-react": "^0.300.0",
         "next": "14.2.35",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "tailwind-merge": "^2.0.0",
       },
       "devDependencies": {
         "@types/node": "^20.10.5",
@@ -248,6 +251,8 @@
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -535,6 +540,8 @@
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "lucide-react": ["lucide-react@0.300.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0" } }, "sha512-rQxUUCmWAvNLoAsMZ5j04b2+OJv6UuNLYMY7VK0eVlm4aTwUEjEEHc09/DipkNIlhXUSDn2xoyIzVT0uh7dRsg=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
@@ -730,6 +737,8 @@
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "tailwind-merge": ["tailwind-merge@2.6.0", "", {}, "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA=="],
 
     "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -9,9 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "clsx": "^2.0.0",
+    "lucide-react": "^0.300.0",
     "next": "14.2.35",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "tailwind-merge": "^2.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.5",

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1,3 +1,35 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@import url('https://fonts.googleapis.com/css2?family=Antonio:wght@400;700&display=swap');
+
+@layer base {
+  :root {
+    --lcars-orange: #ff9900;
+    --lcars-yellow: #ffcc00;
+    --lcars-blue: #9999ff;
+    --lcars-purple: #cc99cc;
+    --lcars-red: #cc6666;
+    --lcars-peach: #ffcc99;
+    --lcars-tan: #cc9966;
+    --lcars-lavender: #9999cc;
+    --lcars-black: #000000;
+    --lcars-dark: #1a1a2e;
+    --lcars-text: #ff9900;
+    --lcars-text-dim: #cc7700;
+
+    --status-available: #66cc66;
+    --status-missing: #cc6666;
+    --status-downloading: #6699cc;
+    --status-processing: #cc99cc;
+  }
+
+  body {
+    font-family: 'Antonio', 'Helvetica Neue', sans-serif;
+    background-color: var(--lcars-black);
+    color: var(--lcars-text);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+}

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,19 +1,22 @@
-import type { Metadata } from 'next'
-import './globals.css'
+import type { Metadata } from 'next';
+import { LcarsFrame } from '@/components/lcars';
+import './globals.css';
 
 export const metadata: Metadata = {
   title: 'LCARS - Media Management',
   description: 'Media management system',
-}
+};
 
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <LcarsFrame>{children}</LcarsFrame>
+      </body>
     </html>
-  )
+  );
 }

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -1,24 +1,37 @@
+import { LcarsButton, LcarsPanel } from '@/components/lcars';
+
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24">
-      <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm">
-        <h1 className="text-4xl font-bold mb-4">LCARS</h1>
-        <p className="text-xl mb-8">Media Management System</p>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          <div className="rounded-lg border border-gray-300 p-6">
-            <h2 className="text-lg font-semibold mb-2">Frontend</h2>
-            <p className="text-sm text-gray-600">Next.js 14 with Static Export</p>
-          </div>
-          <div className="rounded-lg border border-gray-300 p-6">
-            <h2 className="text-lg font-semibold mb-2">Backend</h2>
-            <p className="text-sm text-gray-600">Rust with Axum</p>
-          </div>
-          <div className="rounded-lg border border-gray-300 p-6">
-            <h2 className="text-lg font-semibold mb-2">Build System</h2>
-            <p className="text-sm text-gray-600">Moon Monorepo</p>
-          </div>
-        </div>
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-lcars-text">Dashboard</h1>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <LcarsPanel title="Frontend" accentColor="orange">
+          <p className="text-lcars-text">Next.js 14 with Static Export</p>
+        </LcarsPanel>
+
+        <LcarsPanel title="Backend" accentColor="blue">
+          <p className="text-lcars-text">Rust with Axum</p>
+        </LcarsPanel>
+
+        <LcarsPanel title="Build System" accentColor="purple">
+          <p className="text-lcars-text">Moon Monorepo</p>
+        </LcarsPanel>
       </div>
-    </main>
-  )
+
+      <div className="flex gap-4">
+        <LcarsButton variant="orange">Orange</LcarsButton>
+        <LcarsButton variant="yellow">Yellow</LcarsButton>
+        <LcarsButton variant="blue">Blue</LcarsButton>
+        <LcarsButton variant="purple">Purple</LcarsButton>
+        <LcarsButton variant="red">Red</LcarsButton>
+      </div>
+
+      <div className="flex gap-4">
+        <LcarsButton size="sm">Small</LcarsButton>
+        <LcarsButton size="md">Medium</LcarsButton>
+        <LcarsButton size="lg">Large</LcarsButton>
+      </div>
+    </div>
+  );
 }

--- a/apps/frontend/src/components/lcars/button.tsx
+++ b/apps/frontend/src/components/lcars/button.tsx
@@ -1,0 +1,46 @@
+import { ButtonHTMLAttributes, forwardRef } from 'react';
+import { cn } from '@/lib/utils';
+
+interface LcarsButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'orange' | 'yellow' | 'blue' | 'purple' | 'red';
+  size?: 'sm' | 'md' | 'lg';
+}
+
+export const LcarsButton = forwardRef<HTMLButtonElement, LcarsButtonProps>(
+  ({ className, variant = 'orange', size = 'md', children, ...props }, ref) => {
+    const variants = {
+      orange: 'bg-lcars-orange hover:bg-lcars-yellow',
+      yellow: 'bg-lcars-yellow hover:bg-lcars-orange',
+      blue: 'bg-lcars-blue hover:bg-lcars-lavender',
+      purple: 'bg-lcars-purple hover:bg-lcars-lavender',
+      red: 'bg-lcars-red hover:bg-lcars-orange',
+    };
+
+    const sizes = {
+      sm: 'px-4 py-1 text-sm',
+      md: 'px-6 py-2 text-base',
+      lg: 'px-8 py-3 text-lg',
+    };
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={cn(
+          'rounded-lcars font-lcars text-lcars-black uppercase tracking-wider',
+          'transition-colors duration-200',
+          'focus:outline-none focus:ring-2 focus:ring-lcars-yellow focus:ring-offset-2 focus:ring-offset-lcars-black',
+          'disabled:opacity-50 disabled:cursor-not-allowed',
+          variants[variant],
+          sizes[size],
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+LcarsButton.displayName = 'LcarsButton';

--- a/apps/frontend/src/components/lcars/frame.tsx
+++ b/apps/frontend/src/components/lcars/frame.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { LcarsSidebar } from './sidebar';
+
+interface LcarsFrameProps {
+  children: React.ReactNode;
+}
+
+export function LcarsFrame({ children }: LcarsFrameProps) {
+  return (
+    <div className="min-h-screen bg-lcars-black flex flex-col">
+      {/* Skip to content link for accessibility */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:bg-lcars-orange focus:text-lcars-black focus:rounded-lg"
+      >
+        Skip to content
+      </a>
+
+      {/* Top bar */}
+      <header className="h-16 flex items-center gap-2 p-2" role="banner">
+        <div
+          className="bg-lcars-purple rounded-l-lcars-lg h-full w-32"
+          aria-hidden="true"
+        />
+        <div className="bg-lcars-orange h-full flex-1 rounded-r-lg flex items-center px-4">
+          <span className="text-lcars-black font-bold text-xl">LCARS</span>
+        </div>
+      </header>
+
+      <div className="flex-1 flex gap-2 p-2">
+        {/* Sidebar */}
+        <LcarsSidebar />
+
+        {/* Main content */}
+        <main id="main-content" className="flex-1 bg-lcars-dark rounded-lg p-4">
+          {children}
+        </main>
+      </div>
+
+      {/* Bottom bar */}
+      <footer className="h-8 flex gap-1 p-2" aria-hidden="true">
+        <div className="h-full flex-1 bg-lcars-orange rounded-l-lg" />
+        <div className="h-full flex-1 bg-lcars-yellow" />
+        <div className="h-full flex-1 bg-lcars-blue" />
+        <div className="h-full flex-1 bg-lcars-purple" />
+        <div className="h-full flex-1 bg-lcars-peach rounded-r-lg" />
+      </footer>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/lcars/index.ts
+++ b/apps/frontend/src/components/lcars/index.ts
@@ -1,0 +1,4 @@
+export { LcarsButton } from './button';
+export { LcarsPanel } from './panel';
+export { LcarsSidebar } from './sidebar';
+export { LcarsFrame } from './frame';

--- a/apps/frontend/src/components/lcars/panel.tsx
+++ b/apps/frontend/src/components/lcars/panel.tsx
@@ -1,0 +1,37 @@
+import { cn } from '@/lib/utils';
+
+interface LcarsPanelProps {
+  title?: string;
+  accentColor?: 'orange' | 'yellow' | 'blue' | 'purple';
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function LcarsPanel({
+  title,
+  accentColor = 'orange',
+  children,
+  className,
+}: LcarsPanelProps) {
+  const colors = {
+    orange: 'bg-lcars-orange',
+    yellow: 'bg-lcars-yellow',
+    blue: 'bg-lcars-blue',
+    purple: 'bg-lcars-purple',
+  };
+
+  return (
+    <div className={cn('flex', className)}>
+      {/* Accent bar */}
+      <div className={cn('w-2 rounded-l-lcars', colors[accentColor])} />
+
+      {/* Content */}
+      <div className="flex-1 bg-lcars-dark rounded-r-lg p-4">
+        {title && (
+          <h3 className="text-lcars-text-dim text-sm mb-2">{title}</h3>
+        )}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/lcars/sidebar.tsx
+++ b/apps/frontend/src/components/lcars/sidebar.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Film, Tv, Music, Download, Settings, Home } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const navItems = [
+  { href: '/', icon: Home, label: 'Dashboard' },
+  { href: '/movies', icon: Film, label: 'Movies' },
+  { href: '/tv', icon: Tv, label: 'TV Shows' },
+  { href: '/music', icon: Music, label: 'Music' },
+  { href: '/downloads', icon: Download, label: 'Downloads' },
+  { href: '/settings', icon: Settings, label: 'Settings' },
+];
+
+export function LcarsSidebar() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="w-48 flex flex-col gap-1">
+      {navItems.map((item) => {
+        const isActive =
+          pathname === item.href ||
+          (item.href !== '/' && pathname.startsWith(item.href));
+
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            aria-current={isActive ? 'page' : undefined}
+            className={cn(
+              'flex items-center gap-3 px-4 py-3 rounded-lg transition-colors',
+              'focus:outline-none focus:ring-2 focus:ring-lcars-yellow focus:ring-offset-2 focus:ring-offset-lcars-black',
+              isActive
+                ? 'bg-lcars-orange text-lcars-black'
+                : 'bg-lcars-dark text-lcars-text hover:bg-lcars-tan hover:text-lcars-black'
+            )}
+          >
+            <item.icon size={20} aria-hidden="true" />
+            <span>{item.label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/frontend/src/lib/utils.ts
+++ b/apps/frontend/src/lib/utils.ts
@@ -1,0 +1,21 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+}
+
+export function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -5,7 +5,37 @@ module.exports = {
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        lcars: {
+          orange: 'var(--lcars-orange)',
+          yellow: 'var(--lcars-yellow)',
+          blue: 'var(--lcars-blue)',
+          purple: 'var(--lcars-purple)',
+          red: 'var(--lcars-red)',
+          peach: 'var(--lcars-peach)',
+          tan: 'var(--lcars-tan)',
+          lavender: 'var(--lcars-lavender)',
+          black: 'var(--lcars-black)',
+          dark: 'var(--lcars-dark)',
+          text: 'var(--lcars-text)',
+          'text-dim': 'var(--lcars-text-dim)',
+        },
+        status: {
+          available: 'var(--status-available)',
+          missing: 'var(--status-missing)',
+          downloading: 'var(--status-downloading)',
+          processing: 'var(--status-processing)',
+        },
+      },
+      fontFamily: {
+        lcars: ['Antonio', 'Helvetica Neue', 'sans-serif'],
+      },
+      borderRadius: {
+        lcars: '1.5rem',
+        'lcars-lg': '2.5rem',
+      },
+    },
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
## Summary
- Implements the LCARS (Star Trek) design system for the frontend application
- Adds LCARS color palette, typography (Antonio font), and base UI components
- Creates LcarsButton, LcarsPanel, LcarsSidebar, and LcarsFrame components
- Updates layout and page to use the new design system
- Includes accessibility improvements (skip link, ARIA attributes, focus styles)

## Changes
- `apps/frontend/package.json` - Added clsx, tailwind-merge, lucide-react dependencies
- `apps/frontend/src/app/globals.css` - LCARS CSS custom properties and body styles
- `apps/frontend/tailwind.config.js` - Extended with LCARS colors, fonts, border-radius
- `apps/frontend/src/lib/utils.ts` - cn, formatBytes, formatDuration utilities
- `apps/frontend/src/components/lcars/` - New LCARS components
- `apps/frontend/src/app/layout.tsx` - Uses LcarsFrame layout
- `apps/frontend/src/app/page.tsx` - Demo page with LCARS components

## Test plan
- [x] Run `moon ci` - all checks pass (typecheck, lint, build)
- [ ] Visual inspection in browser
- [ ] Verify keyboard navigation works
- [ ] Verify active nav item highlighting

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)