### PR TITLE
feat(frontend): add API client and state management

### DIFF
--- a/apps/frontend/bun.lock
+++ b/apps/frontend/bun.lock
@@ -5,12 +5,15 @@
     "": {
       "name": "frontend",
       "dependencies": {
+        "@tanstack/react-query": "^5.0.0",
         "clsx": "^2.0.0",
         "lucide-react": "^0.300.0",
         "next": "14.2.35",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "reconnecting-websocket": "^4.4.0",
         "tailwind-merge": "^2.0.0",
+        "zustand": "^4.4.0",
       },
       "devDependencies": {
         "@types/node": "^20.10.5",
@@ -99,6 +102,10 @@
     "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.5", "", { "dependencies": { "@swc/counter": "^0.1.3", "tslib": "^2.4.0" } }, "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.90.16", "", {}, "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.90.16", "", { "dependencies": { "@tanstack/query-core": "5.90.16" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-bpMGOmV4OPmif7TNMteU/Ehf/hoC0Kf98PDc0F4BZkFrEapRMEqI/V6YS0lyzwSV6PQpY1y4xxArUIfBW5LVxQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -652,6 +659,8 @@
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
+    "reconnecting-websocket": ["reconnecting-websocket@4.4.0", "", {}, "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng=="],
+
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
@@ -784,6 +793,8 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -805,6 +816,8 @@
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -9,12 +9,15 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.0.0",
     "clsx": "^2.0.0",
     "lucide-react": "^0.300.0",
     "next": "14.2.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "tailwind-merge": "^2.0.0"
+    "reconnecting-websocket": "^4.4.0",
+    "tailwind-merge": "^2.0.0",
+    "zustand": "^4.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.5",

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { LcarsFrame } from '@/components/lcars';
+import { Providers } from '@/lib/providers';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -15,7 +16,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <LcarsFrame>{children}</LcarsFrame>
+        <Providers>
+          <LcarsFrame>{children}</LcarsFrame>
+        </Providers>
       </body>
     </html>
   );

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -1,0 +1,430 @@
+import type {
+  User,
+  Movie,
+  TvShow,
+  Episode,
+  Artist,
+  Album,
+  Track,
+  Download,
+  Release,
+  SystemStatus,
+  PaginatedResponse,
+  TmdbMovieSearchResult,
+  TmdbTvSearchResult,
+  MusicBrainzArtistSearchResult,
+  MusicBrainzAlbumSearchResult,
+  ActivityEvent,
+} from './types';
+
+// Custom error class for API errors
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code?: string
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+export class AuthError extends ApiError {
+  constructor(message: string = 'Authentication required') {
+    super(message, 401, 'AUTH_ERROR');
+    this.name = 'AuthError';
+  }
+}
+
+export class ApiClient {
+  private baseUrl: string;
+  private token: string | null = null;
+
+  constructor(baseUrl: string = '/api') {
+    this.baseUrl = baseUrl;
+  }
+
+  setToken(token: string | null) {
+    this.token = token;
+  }
+
+  getToken(): string | null {
+    return this.token;
+  }
+
+  private async request<T>(
+    endpoint: string,
+    options: RequestInit & { signal?: AbortSignal } = {}
+  ): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    if (this.token) {
+      headers['Authorization'] = `Bearer ${this.token}`;
+    }
+
+    const response = await fetch(url, {
+      ...options,
+      signal: options.signal,
+      headers: {
+        ...headers,
+        ...(options.headers as Record<string, string>),
+      },
+    });
+
+    if (!response.ok) {
+      // Handle authentication errors specially
+      if (response.status === 401) {
+        throw new AuthError();
+      }
+
+      // Don't expose full error details in production
+      const errorText = await response.text();
+      const message = process.env.NODE_ENV === 'production'
+        ? `Request failed with status ${response.status}`
+        : errorText || `HTTP ${response.status}`;
+
+      throw new ApiError(message, response.status);
+    }
+
+    // Handle empty responses
+    const text = await response.text();
+    return text ? JSON.parse(text) : (null as T);
+  }
+
+  // Auth endpoints
+  async login(username: string, password: string): Promise<{ token: string; user: User }> {
+    return this.request('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ username, password }),
+    });
+  }
+
+  async logout(): Promise<{ success: boolean }> {
+    return this.request('/auth/logout', { method: 'POST' });
+  }
+
+  async me(): Promise<User> {
+    return this.request('/auth/me');
+  }
+
+  // Movies endpoints
+  async getMovies(params?: {
+    status?: string;
+    monitored?: boolean;
+    search?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<PaginatedResponse<Movie>> {
+    const searchParams = new URLSearchParams();
+    if (params?.status) searchParams.append('status', params.status);
+    if (params?.monitored !== undefined) searchParams.append('monitored', String(params.monitored));
+    if (params?.search) searchParams.append('search', params.search);
+    if (params?.page) searchParams.append('page', String(params.page));
+    if (params?.limit) searchParams.append('limit', String(params.limit));
+
+    const query = searchParams.toString();
+    return this.request(`/movies${query ? `?${query}` : ''}`);
+  }
+
+  async getMovie(id: number): Promise<Movie> {
+    return this.request(`/movies/${id}`);
+  }
+
+  async addMovie(data: {
+    tmdb_id: number;
+    monitored?: boolean;
+    quality_limit?: string;
+  }): Promise<Movie> {
+    return this.request('/movies', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updateMovie(id: number, data: {
+    monitored?: boolean;
+    quality_limit?: string;
+  }): Promise<Movie> {
+    return this.request(`/movies/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteMovie(id: number, deleteFiles: boolean = false): Promise<{ success: boolean }> {
+    return this.request(`/movies/${id}?delete_files=${deleteFiles}`, {
+      method: 'DELETE',
+    });
+  }
+
+  async searchMovieReleases(id: number): Promise<Release[]> {
+    return this.request(`/movies/${id}/search`, { method: 'POST' });
+  }
+
+  async downloadMovie(id: number, data: { release_id?: string; magnet?: string }): Promise<Download> {
+    return this.request(`/movies/${id}/download`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  // TV Shows endpoints
+  async getTvShows(params?: {
+    status?: string;
+    monitored?: boolean;
+    search?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<PaginatedResponse<TvShow>> {
+    const searchParams = new URLSearchParams();
+    if (params?.status) searchParams.append('status', params.status);
+    if (params?.monitored !== undefined) searchParams.append('monitored', String(params.monitored));
+    if (params?.search) searchParams.append('search', params.search);
+    if (params?.page) searchParams.append('page', String(params.page));
+    if (params?.limit) searchParams.append('limit', String(params.limit));
+
+    const query = searchParams.toString();
+    return this.request(`/tv${query ? `?${query}` : ''}`);
+  }
+
+  async getTvShow(id: number): Promise<TvShow> {
+    return this.request(`/tv/${id}`);
+  }
+
+  async addTvShow(data: {
+    tmdb_id: number;
+    monitored?: boolean;
+    quality_limit?: string;
+  }): Promise<TvShow> {
+    return this.request('/tv', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updateTvShow(id: number, data: {
+    monitored?: boolean;
+    quality_limit?: string;
+  }): Promise<TvShow> {
+    return this.request(`/tv/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteTvShow(id: number, deleteFiles: boolean = false): Promise<{ success: boolean }> {
+    return this.request(`/tv/${id}?delete_files=${deleteFiles}`, {
+      method: 'DELETE',
+    });
+  }
+
+  async updateEpisode(
+    showId: number,
+    seasonNumber: number,
+    episodeNumber: number,
+    data: { monitored?: boolean }
+  ): Promise<Episode> {
+    return this.request(`/tv/${showId}/season/${seasonNumber}/episode/${episodeNumber}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async searchEpisodeReleases(
+    showId: number,
+    seasonNumber: number,
+    episodeNumber: number
+  ): Promise<Release[]> {
+    return this.request(
+      `/tv/${showId}/season/${seasonNumber}/episode/${episodeNumber}/search`,
+      { method: 'POST' }
+    );
+  }
+
+  async downloadEpisode(
+    showId: number,
+    seasonNumber: number,
+    episodeNumber: number,
+    data: { release_id?: string; magnet?: string }
+  ): Promise<Download> {
+    return this.request(
+      `/tv/${showId}/season/${seasonNumber}/episode/${episodeNumber}/download`,
+      {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }
+    );
+  }
+
+  // Music - Artists endpoints
+  async getArtists(params?: {
+    monitored?: boolean;
+    search?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<PaginatedResponse<Artist>> {
+    const searchParams = new URLSearchParams();
+    if (params?.monitored !== undefined) searchParams.append('monitored', String(params.monitored));
+    if (params?.search) searchParams.append('search', params.search);
+    if (params?.page) searchParams.append('page', String(params.page));
+    if (params?.limit) searchParams.append('limit', String(params.limit));
+
+    const query = searchParams.toString();
+    return this.request(`/artists${query ? `?${query}` : ''}`);
+  }
+
+  async getArtist(id: number): Promise<Artist> {
+    return this.request(`/artists/${id}`);
+  }
+
+  async addArtist(data: {
+    mbid: string;
+    monitored?: boolean;
+    quality_limit?: string;
+  }): Promise<Artist> {
+    return this.request('/artists', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updateArtist(id: number, data: {
+    monitored?: boolean;
+    quality_limit?: string;
+  }): Promise<Artist> {
+    return this.request(`/artists/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteArtist(id: number, deleteFiles: boolean = false): Promise<{ success: boolean }> {
+    return this.request(`/artists/${id}?delete_files=${deleteFiles}`, {
+      method: 'DELETE',
+    });
+  }
+
+  // Music - Albums endpoints
+  async getAlbums(params?: {
+    artist_id?: number;
+    status?: string;
+    monitored?: boolean;
+    search?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<PaginatedResponse<Album>> {
+    const searchParams = new URLSearchParams();
+    if (params?.artist_id) searchParams.append('artist_id', String(params.artist_id));
+    if (params?.status) searchParams.append('status', params.status);
+    if (params?.monitored !== undefined) searchParams.append('monitored', String(params.monitored));
+    if (params?.search) searchParams.append('search', params.search);
+    if (params?.page) searchParams.append('page', String(params.page));
+    if (params?.limit) searchParams.append('limit', String(params.limit));
+
+    const query = searchParams.toString();
+    return this.request(`/albums${query ? `?${query}` : ''}`);
+  }
+
+  async getAlbum(id: number): Promise<Album> {
+    return this.request(`/albums/${id}`);
+  }
+
+  async updateAlbum(id: number, data: {
+    monitored?: boolean;
+    quality_limit?: string;
+  }): Promise<Album> {
+    return this.request(`/albums/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteAlbum(id: number, deleteFiles: boolean = false): Promise<{ success: boolean }> {
+    return this.request(`/albums/${id}?delete_files=${deleteFiles}`, {
+      method: 'DELETE',
+    });
+  }
+
+  async searchAlbumReleases(id: number): Promise<Release[]> {
+    return this.request(`/albums/${id}/search`, { method: 'POST' });
+  }
+
+  async downloadAlbum(id: number, data: { release_id?: string; magnet?: string }): Promise<Download> {
+    return this.request(`/albums/${id}/download`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  // Downloads endpoints
+  async getDownloads(status?: string): Promise<Download[]> {
+    const query = status ? `?status=${status}` : '';
+    return this.request(`/downloads${query}`);
+  }
+
+  async getDownload(id: number): Promise<Download> {
+    return this.request(`/downloads/${id}`);
+  }
+
+  async pauseDownload(id: number): Promise<Download> {
+    return this.request(`/downloads/${id}/pause`, { method: 'POST' });
+  }
+
+  async resumeDownload(id: number): Promise<Download> {
+    return this.request(`/downloads/${id}/resume`, { method: 'POST' });
+  }
+
+  async deleteDownload(id: number, deleteFiles: boolean = false): Promise<{ success: boolean }> {
+    return this.request(`/downloads/${id}?delete_files=${deleteFiles}`, {
+      method: 'DELETE',
+    });
+  }
+
+  // Search endpoints
+  async searchTmdbMovies(query: string, year?: number): Promise<TmdbMovieSearchResult[]> {
+    const searchParams = new URLSearchParams({ q: query });
+    if (year) searchParams.append('year', String(year));
+    return this.request(`/search/tmdb/movies?${searchParams.toString()}`);
+  }
+
+  async searchTmdbTv(query: string): Promise<TmdbTvSearchResult[]> {
+    const searchParams = new URLSearchParams({ q: query });
+    return this.request(`/search/tmdb/tv?${searchParams.toString()}`);
+  }
+
+  async searchMusicBrainzArtists(query: string): Promise<MusicBrainzArtistSearchResult[]> {
+    const searchParams = new URLSearchParams({ q: query });
+    return this.request(`/search/musicbrainz/artists?${searchParams.toString()}`);
+  }
+
+  async searchMusicBrainzAlbums(query: string, artistMbid?: string): Promise<MusicBrainzAlbumSearchResult[]> {
+    const searchParams = new URLSearchParams({ q: query });
+    if (artistMbid) searchParams.append('artist_mbid', artistMbid);
+    return this.request(`/search/musicbrainz/albums?${searchParams.toString()}`);
+  }
+
+  // System endpoints
+  async getSystemStatus(): Promise<SystemStatus> {
+    return this.request('/system/status');
+  }
+
+  async getActivity(params?: {
+    type?: string;
+    limit?: number;
+    before?: string;
+  }): Promise<ActivityEvent[]> {
+    const searchParams = new URLSearchParams();
+    if (params?.type) searchParams.append('type', params.type);
+    if (params?.limit) searchParams.append('limit', String(params.limit));
+    if (params?.before) searchParams.append('before', params.before);
+
+    const query = searchParams.toString();
+    return this.request(`/system/activity${query ? `?${query}` : ''}`);
+  }
+}
+
+// Export singleton instance
+export const api = new ApiClient();

--- a/apps/frontend/src/lib/providers.tsx
+++ b/apps/frontend/src/lib/providers.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useEffect, useState, useRef } from 'react';
+import { useAuthStore } from './stores/auth';
+import { useDownloadsStore } from './stores/downloads';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30000, // 30 seconds
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [mounted, setMounted] = useState(false);
+  const initRef = useRef(false);
+  const checkAuth = useAuthStore((state) => state.checkAuth);
+  const connectWs = useDownloadsStore((state) => state.connect);
+  const disconnectWs = useDownloadsStore((state) => state.disconnect);
+
+  useEffect(() => {
+    setMounted(true);
+
+    // Prevent double initialization in strict mode
+    if (initRef.current) return;
+    initRef.current = true;
+
+    // Initialize auth first, then connect WebSocket
+    // This ensures token is available for WebSocket authentication
+    const initializeApp = async () => {
+      await checkAuth();
+      connectWs();
+    };
+
+    initializeApp();
+
+    // Cleanup WebSocket on unmount
+    return () => {
+      disconnectWs();
+    };
+  }, [checkAuth, connectWs, disconnectWs]);
+
+  // Render children immediately to avoid layout shift
+  // Zustand handles SSR hydration automatically
+  if (!mounted) {
+    return <>{children}</>;
+  }
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+}

--- a/apps/frontend/src/lib/stores/auth.ts
+++ b/apps/frontend/src/lib/stores/auth.ts
@@ -1,0 +1,84 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { api } from '../api';
+import type { User } from '../types';
+
+/**
+ * Authentication store using Zustand with localStorage persistence.
+ *
+ * Security Note: Token is stored in localStorage for simplicity.
+ * For enhanced security in production, consider:
+ * - Using httpOnly cookies (requires backend Set-Cookie support)
+ * - Implementing Content Security Policy (CSP) headers
+ * - Adding token expiration validation
+ */
+
+interface AuthState {
+  user: User | null;
+  token: string | null;
+  isLoading: boolean;
+  login: (username: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  checkAuth: () => Promise<void>;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      user: null,
+      token: null,
+      isLoading: false,
+
+      login: async (username: string, password: string) => {
+        set({ isLoading: true });
+        try {
+          const { token, user } = await api.login(username, password);
+          api.setToken(token);
+          set({ user, token, isLoading: false });
+        } catch (error) {
+          set({ isLoading: false });
+          throw error;
+        }
+      },
+
+      logout: async () => {
+        set({ isLoading: true });
+        try {
+          await api.logout();
+        } catch (error) {
+          console.error('Logout error:', error);
+        } finally {
+          api.setToken(null);
+          set({ user: null, token: null, isLoading: false });
+        }
+      },
+
+      checkAuth: async () => {
+        const { token } = get();
+        if (!token) {
+          set({ user: null, isLoading: false });
+          return;
+        }
+
+        set({ isLoading: true });
+        api.setToken(token);
+
+        try {
+          const user = await api.me();
+          set({ user, isLoading: false });
+        } catch (error) {
+          console.error('Auth check failed:', error);
+          api.setToken(null);
+          set({ user: null, token: null, isLoading: false });
+        }
+      },
+    }),
+    {
+      name: 'lcars-auth',
+      partialize: (state) => ({
+        token: state.token,
+        user: state.user,
+      }),
+    }
+  )
+);

--- a/apps/frontend/src/lib/stores/downloads.ts
+++ b/apps/frontend/src/lib/stores/downloads.ts
@@ -1,0 +1,204 @@
+import { create } from 'zustand';
+import ReconnectingWebSocket from 'reconnecting-websocket';
+import type { Download } from '../types';
+import { useAuthStore } from './auth';
+
+// WebSocket configuration constants
+const WS_CONFIG = {
+  maxReconnectionDelay: 10000,
+  minReconnectionDelay: 1000,
+  reconnectionDelayGrowFactor: 1.3,
+  connectionTimeout: 4000,
+  maxRetries: Infinity,
+} as const;
+
+interface DownloadsState {
+  downloads: Map<number, Download>;
+  ws: ReconnectingWebSocket | null;
+  isConnected: boolean;
+  connectionError: string | null;
+  connect: () => void;
+  disconnect: () => void;
+  updateDownload: (download: Partial<Download> & { id: number }) => void;
+  setDownloads: (downloads: Download[]) => void;
+  getDownload: (id: number) => Download | undefined;
+  removeDownload: (id: number) => void;
+  clearOldDownloads: (maxAge?: number) => void;
+}
+
+export const useDownloadsStore = create<DownloadsState>((set, get) => ({
+  downloads: new Map(),
+  ws: null,
+  isConnected: false,
+  connectionError: null,
+
+  connect: () => {
+    const { ws: existingWs } = get();
+    if (existingWs) {
+      return;
+    }
+
+    // Determine WebSocket URL based on current location
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const host = window.location.host;
+
+    // Include auth token in WebSocket connection if available
+    const token = useAuthStore.getState().token;
+    const wsUrl = token
+      ? `${protocol}//${host}/api/ws?token=${encodeURIComponent(token)}`
+      : `${protocol}//${host}/api/ws`;
+
+    const ws = new ReconnectingWebSocket(wsUrl, [], {
+      ...WS_CONFIG,
+      debug: false,
+    });
+
+    ws.addEventListener('open', () => {
+      set({ isConnected: true, connectionError: null });
+    });
+
+    ws.addEventListener('close', (event) => {
+      const error = event.reason || null;
+      set({ isConnected: false, connectionError: error });
+    });
+
+    ws.addEventListener('error', () => {
+      set({ connectionError: 'WebSocket connection error' });
+    });
+
+    ws.addEventListener('message', (event) => {
+      try {
+        const message = JSON.parse(event.data);
+        handleWebSocketMessage(message, get, set);
+      } catch {
+        // Silently ignore malformed messages in production
+        if (process.env.NODE_ENV !== 'production') {
+          console.error('Failed to parse WebSocket message');
+        }
+      }
+    });
+
+    set({ ws, isConnected: ws.readyState === WebSocket.OPEN });
+  },
+
+  disconnect: () => {
+    const { ws } = get();
+    if (ws) {
+      console.log('Disconnecting WebSocket');
+      ws.close();
+      set({ ws: null, isConnected: false });
+    }
+  },
+
+  updateDownload: (download) => {
+    set((state) => {
+      const downloads = new Map(state.downloads);
+      const existing = downloads.get(download.id);
+      if (existing) {
+        downloads.set(download.id, { ...existing, ...download });
+      } else {
+        // If we don't have the full download object, we'll need to fetch it
+        downloads.set(download.id, download as Download);
+      }
+      return { downloads };
+    });
+  },
+
+  setDownloads: (downloadsList) => {
+    const downloads = new Map(downloadsList.map((d) => [d.id, d]));
+    set({ downloads });
+  },
+
+  getDownload: (id) => {
+    return get().downloads.get(id);
+  },
+
+  removeDownload: (id) => {
+    set((state) => {
+      const downloads = new Map(state.downloads);
+      downloads.delete(id);
+      return { downloads };
+    });
+  },
+
+  clearOldDownloads: (maxAge = 24 * 60 * 60 * 1000) => {
+    // Default: clear completed downloads older than 24 hours
+    const now = Date.now();
+    set((state) => {
+      const downloads = new Map(state.downloads);
+      for (const [id, download] of downloads) {
+        if (
+          download.status === 'completed' &&
+          download.completed_at &&
+          now - new Date(download.completed_at).getTime() > maxAge
+        ) {
+          downloads.delete(id);
+        }
+      }
+      return { downloads };
+    });
+  },
+}));
+
+// Handle WebSocket messages
+function handleWebSocketMessage(
+  message: any,
+  get: () => DownloadsState,
+  set: (partial: Partial<DownloadsState>) => void
+) {
+  const { type, ...data } = message;
+
+  switch (type) {
+    case 'download:added':
+      if (data.download) {
+        get().updateDownload(data.download);
+      }
+      break;
+
+    case 'download:progress':
+      get().updateDownload({
+        id: data.id,
+        progress: data.progress,
+        download_speed: data.download_speed,
+        upload_speed: data.upload_speed,
+        peers: data.peers,
+      });
+      break;
+
+    case 'download:status':
+      get().updateDownload({
+        id: data.id,
+        status: data.status,
+        error_message: data.error_message,
+      });
+      break;
+
+    case 'download:completed':
+      get().updateDownload({
+        id: data.id,
+        status: 'completed',
+        progress: 1,
+        completed_at: new Date().toISOString(),
+      });
+      break;
+
+    case 'download:error':
+      get().updateDownload({
+        id: data.id,
+        status: 'failed',
+        error_message: data.error_message || 'Unknown error',
+      });
+      break;
+
+    case 'media:added':
+    case 'media:updated':
+    case 'media:deleted':
+    case 'system:status':
+      // These can be handled by other stores or components if needed
+      console.log('Received message:', type, data);
+      break;
+
+    default:
+      console.warn('Unknown WebSocket message type:', type);
+  }
+}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -1,0 +1,281 @@
+// User types
+export interface User {
+  id: number;
+  username: string;
+  role: 'admin' | 'user';
+  created_at: string;
+}
+
+// Media status types
+export type MediaStatus = 'missing' | 'searching' | 'downloading' | 'processing' | 'available';
+export type AlbumStatus = 'missing' | 'searching' | 'downloading' | 'processing' | 'partial' | 'available';
+export type ShowStatus = 'continuing' | 'ended' | 'canceled' | 'upcoming';
+
+// Movie types
+export interface Movie {
+  id: number;
+  tmdb_id: number;
+  imdb_id?: string;
+  title: string;
+  original_title?: string;
+  year: number;
+  overview?: string;
+  poster_path?: string;
+  backdrop_path?: string;
+  runtime_minutes?: number;
+  genres: string[];
+  status: MediaStatus;
+  monitored: boolean;
+  quality_limit: string;
+  file_path?: string;
+  file_size?: number;
+  added_at: string;
+}
+
+// TV types
+export interface TvShow {
+  id: number;
+  tmdb_id: number;
+  imdb_id?: string;
+  title: string;
+  original_title?: string;
+  year_start?: number;
+  year_end?: number;
+  overview?: string;
+  poster_path?: string;
+  backdrop_path?: string;
+  status: ShowStatus;
+  monitored: boolean;
+  quality_limit: string;
+  seasons: Season[];
+  added_at: string;
+}
+
+export interface Season {
+  season_number: number;
+  episode_count: number;
+  available_count: number;
+  episodes: Episode[];
+}
+
+export interface Episode {
+  id: number;
+  show_id: number;
+  tmdb_id?: number;
+  season_number: number;
+  episode_number: number;
+  title?: string;
+  overview?: string;
+  air_date?: string;
+  runtime_minutes?: number;
+  still_path?: string;
+  status: MediaStatus;
+  monitored: boolean;
+  file_path?: string;
+  file_size?: number;
+}
+
+// Music types
+export interface Artist {
+  id: number;
+  mbid: string;
+  name: string;
+  sort_name?: string;
+  disambiguation?: string;
+  artist_type?: string;
+  country?: string;
+  begin_date?: string;
+  end_date?: string;
+  overview?: string;
+  image_path?: string;
+  monitored: boolean;
+  quality_limit: string;
+  albums: Album[];
+  added_at: string;
+}
+
+export interface Album {
+  id: number;
+  mbid: string;
+  artist_id: number;
+  title: string;
+  album_type?: string;
+  release_date?: string;
+  overview?: string;
+  cover_path?: string;
+  total_tracks?: number;
+  status: AlbumStatus;
+  monitored: boolean;
+  quality_limit: string;
+  tracks: Track[];
+  added_at: string;
+}
+
+export interface Track {
+  id: number;
+  mbid?: string;
+  album_id: number;
+  artist_id?: number;
+  title: string;
+  track_number: number;
+  disc_number: number;
+  duration_ms?: number;
+  status: MediaStatus;
+  monitored: boolean;
+  file_path?: string;
+  file_size?: number;
+  audio_format?: string;
+  bitrate?: number;
+  sample_rate?: number;
+  bit_depth?: number;
+}
+
+// Download types
+export type DownloadStatus = 'queued' | 'downloading' | 'seeding' | 'processing' | 'completed' | 'failed' | 'paused';
+
+export interface Download {
+  id: number;
+  info_hash: string;
+  name: string;
+  media_type: 'movie' | 'episode' | 'album' | 'track';
+  media_id: number;
+  status: DownloadStatus;
+  progress: number;
+  download_speed: number;
+  upload_speed: number;
+  size_bytes?: number;
+  downloaded_bytes: number;
+  uploaded_bytes: number;
+  ratio: number;
+  peers: number;
+  error_message?: string;
+  added_at: string;
+  started_at?: string;
+  completed_at?: string;
+}
+
+// Release types
+export type Quality = '2160p' | '1080p' | '720p' | '480p' | 'unknown';
+export type Source = 'bluray' | 'webdl' | 'webrip' | 'hdtv' | 'dvd' | 'cam' | 'unknown';
+
+export interface Release {
+  id: string;
+  title: string;
+  indexer: string;
+  magnet: string;
+  size_bytes: number;
+  seeders: number;
+  leechers: number;
+  quality: Quality;
+  source: Source;
+  codec?: string;
+  audio?: string;
+  group?: string;
+  proper: boolean;
+  repack: boolean;
+  uploaded_at: string;
+}
+
+// System types
+export interface SystemStatus {
+  version: string;
+  uptime_seconds: number;
+  database_size_bytes: number;
+  downloads: {
+    active: number;
+    queued: number;
+    seeding: number;
+  };
+  storage: {
+    mounts: MountStatus[];
+  };
+  vpn: {
+    enabled: boolean;
+    interface: string;
+    connected: boolean;
+    public_ip?: string;
+  };
+}
+
+export interface MountStatus {
+  name: string;
+  type: 'local' | 'smb';
+  available: boolean;
+  total_bytes?: number;
+  free_bytes?: number;
+  error?: string;
+}
+
+// Pagination
+export interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  pages: number;
+}
+
+// External search result types
+export interface TmdbMovieSearchResult {
+  id: number;
+  title: string;
+  original_title?: string;
+  overview?: string;
+  poster_path?: string;
+  backdrop_path?: string;
+  release_date?: string;
+  vote_average?: number;
+  vote_count?: number;
+  genre_ids?: number[];
+}
+
+export interface TmdbTvSearchResult {
+  id: number;
+  name: string;
+  original_name?: string;
+  overview?: string;
+  poster_path?: string;
+  backdrop_path?: string;
+  first_air_date?: string;
+  vote_average?: number;
+  vote_count?: number;
+  genre_ids?: number[];
+}
+
+export interface MusicBrainzArtistSearchResult {
+  id: string;
+  name: string;
+  sort_name?: string;
+  disambiguation?: string;
+  type?: string;
+  country?: string;
+  score?: number;
+}
+
+export interface MusicBrainzAlbumSearchResult {
+  id: string;
+  title: string;
+  artist_credit?: string;
+  release_date?: string;
+  type?: string;
+  country?: string;
+  score?: number;
+}
+
+// Activity event types
+export type ActivityEventType =
+  | 'media:added'
+  | 'media:updated'
+  | 'media:deleted'
+  | 'download:started'
+  | 'download:completed'
+  | 'download:failed'
+  | 'system:startup'
+  | 'system:error';
+
+export interface ActivityEvent {
+  id: number;
+  type: ActivityEventType;
+  message: string;
+  details?: Record<string, unknown>;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary

- Add dependencies: `@tanstack/react-query`, `zustand`, `reconnecting-websocket`
- Create comprehensive TypeScript types for all API entities (users, media, downloads, releases, system status, search results, activity events)
- Implement type-safe API client with JWT token management, custom error classes (`ApiError`, `AuthError`), and AbortController support
- Create auth store with Zustand persistence for login/logout/checkAuth functionality
- Create downloads store with WebSocket for real-time download progress updates, including authentication token support
- Setup React Query provider with sensible defaults (30s stale time, 1 retry)
- Update layout to wrap app with providers

## Test plan

- [ ] Verify TypeScript compilation passes (`moon run frontend:typecheck`)
- [ ] Verify ESLint passes (`moon run frontend:lint`)
- [ ] Verify production build succeeds (`moon run frontend:build`)
- [ ] Test API client token handling with backend auth endpoints
- [ ] Test WebSocket connection and real-time download updates
- [ ] Verify auth store persistence across page refreshes

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)