### PR TITLE
[Frontend] Media components (cards, lists, modals)

### DIFF
--- a/apps/frontend/src/components/artist-card.tsx
+++ b/apps/frontend/src/components/artist-card.tsx
@@ -1,0 +1,84 @@
+import { forwardRef, HTMLAttributes } from 'react';
+import Image from 'next/image';
+import { Music } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { Artist } from '@/lib/types';
+
+interface ArtistCardProps extends HTMLAttributes<HTMLDivElement> {
+  artist: Artist;
+  onSelect?: () => void;
+}
+
+export const ArtistCard = forwardRef<HTMLDivElement, ArtistCardProps>(
+  ({ artist, onSelect, className, ...props }, ref) => {
+    const imageUrl = artist.image_path || null;
+    const albumCount = artist.albums?.length || 0;
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+      if ((e.key === 'Enter' || e.key === ' ') && onSelect) {
+        e.preventDefault();
+        onSelect();
+      }
+    };
+
+    return (
+      <div
+        ref={ref}
+        role={onSelect ? 'button' : undefined}
+        tabIndex={onSelect ? 0 : undefined}
+        className={cn(
+          'group relative overflow-hidden rounded-lcars',
+          'bg-lcars-dark transition-all duration-300',
+          onSelect && 'cursor-pointer hover:ring-2 hover:ring-lcars-purple hover:scale-105 focus:outline-none focus:ring-2 focus:ring-lcars-purple',
+          className
+        )}
+        onClick={onSelect}
+        onKeyDown={handleKeyDown}
+        {...props}
+      >
+        {/* Artist Image - Square Aspect Ratio */}
+        <div className="relative aspect-square w-full overflow-hidden bg-lcars-black">
+          {imageUrl ? (
+            <Image
+              src={imageUrl}
+              alt={artist.name}
+              fill
+              className="object-cover transition-opacity duration-300 group-hover:opacity-80"
+              sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 20vw"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center bg-lcars-dark">
+              <Music className="h-16 w-16 text-lcars-purple opacity-30" />
+            </div>
+          )}
+
+          {/* Monitored Badge */}
+          {artist.monitored && (
+            <div className="absolute top-2 right-2">
+              <div className="rounded-lcars bg-lcars-purple px-2 py-1 text-xs font-bold text-lcars-black">
+                MONITORED
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Info Overlay */}
+        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-lcars-black via-lcars-black/80 to-transparent p-3">
+          <h3 className="truncate text-sm font-bold text-lcars-text">
+            {artist.name}
+          </h3>
+          <div className="mt-1 flex items-center justify-between text-xs text-lcars-text-dim">
+            <span>{albumCount} {albumCount === 1 ? 'album' : 'albums'}</span>
+          </div>
+          {artist.disambiguation && (
+            <p className="mt-1 truncate text-xs text-lcars-text-dim">
+              {artist.disambiguation}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+);
+
+ArtistCard.displayName = 'ArtistCard';

--- a/apps/frontend/src/components/download-item.tsx
+++ b/apps/frontend/src/components/download-item.tsx
@@ -1,0 +1,150 @@
+import { forwardRef, HTMLAttributes } from 'react';
+import { Pause, Play, X, RotateCw } from 'lucide-react';
+import { cn, formatBytes, formatSpeed } from '@/lib/utils';
+import { downloadStatusColors } from '@/lib/constants';
+import { LcarsButton } from '@/components/lcars/button';
+import type { Download } from '@/lib/types';
+
+interface DownloadItemProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onPause'> {
+  download: Download;
+  onPause?: (id: number) => void;
+  onResume?: (id: number) => void;
+  onCancel?: (id: number) => void;
+  onRetry?: (id: number) => void;
+}
+
+export const DownloadItem = forwardRef<HTMLDivElement, DownloadItemProps>(
+  ({ download, onPause, onResume, onCancel, onRetry, className, ...props }, ref) => {
+    const canPause = download.status === 'downloading' || download.status === 'seeding';
+    const canResume = download.status === 'paused';
+    const canRetry = download.status === 'failed';
+    const canCancel = !['completed', 'failed'].includes(download.status);
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'rounded-lcars bg-lcars-dark p-4',
+          className
+        )}
+        {...props}
+      >
+        {/* Header */}
+        <div className="mb-3 flex items-start justify-between">
+          <div className="flex-1 pr-4">
+            <h3 className="text-sm font-bold text-lcars-text">
+              {download.name}
+            </h3>
+            <div className="mt-1 flex items-center gap-2 text-xs text-lcars-text-dim">
+              <span className="capitalize">{download.media_type}</span>
+              <span>•</span>
+              <span className={cn('capitalize', downloadStatusColors[download.status])}>
+                {download.status}
+              </span>
+            </div>
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex gap-2">
+            {canPause && (
+              <LcarsButton
+                variant="yellow"
+                size="sm"
+                onClick={() => onPause?.(download.id)}
+                title="Pause"
+              >
+                <Pause className="h-4 w-4" />
+              </LcarsButton>
+            )}
+            {canResume && (
+              <LcarsButton
+                variant="orange"
+                size="sm"
+                onClick={() => onResume?.(download.id)}
+                title="Resume"
+              >
+                <Play className="h-4 w-4" />
+              </LcarsButton>
+            )}
+            {canRetry && (
+              <LcarsButton
+                variant="orange"
+                size="sm"
+                onClick={() => onRetry?.(download.id)}
+                title="Retry"
+              >
+                <RotateCw className="h-4 w-4" />
+              </LcarsButton>
+            )}
+            {canCancel && (
+              <LcarsButton
+                variant="red"
+                size="sm"
+                onClick={() => onCancel?.(download.id)}
+                title="Cancel"
+              >
+                <X className="h-4 w-4" />
+              </LcarsButton>
+            )}
+          </div>
+        </div>
+
+        {/* Progress Bar */}
+        {download.status !== 'failed' && download.status !== 'completed' && (
+          <div className="mb-3">
+            <div className="h-2 w-full overflow-hidden rounded-full bg-lcars-black">
+              <div
+                className={cn(
+                  'h-full transition-all duration-300',
+                  downloadStatusColors[download.status]
+                )}
+                style={{ width: `${download.progress * 100}%` }}
+              />
+            </div>
+            <div className="mt-1 text-xs text-lcars-text-dim">
+              {(download.progress * 100).toFixed(1)}%
+            </div>
+          </div>
+        )}
+
+        {/* Stats */}
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-lcars-text-dim">
+          {download.size_bytes && (
+            <span>
+              Size: {formatBytes(download.size_bytes)}
+            </span>
+          )}
+          {download.download_speed > 0 && (
+            <span>
+              Down: {formatSpeed(download.download_speed)}
+            </span>
+          )}
+          {download.upload_speed > 0 && (
+            <span>
+              Up: {formatSpeed(download.upload_speed)}
+            </span>
+          )}
+          {download.peers > 0 && (
+            <span>
+              Peers: {download.peers}
+            </span>
+          )}
+          {download.ratio > 0 && (
+            <span>
+              Ratio: {download.ratio.toFixed(2)}
+            </span>
+          )}
+        </div>
+
+        {/* Error Message */}
+        {download.error_message && (
+          <div className="mt-3 rounded-lcars bg-status-missing/20 p-2 text-xs text-status-missing">
+            {download.error_message}
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+DownloadItem.displayName = 'DownloadItem';

--- a/apps/frontend/src/components/index.ts
+++ b/apps/frontend/src/components/index.ts
@@ -1,0 +1,6 @@
+export { MediaCard } from './media-card';
+export { ArtistCard } from './artist-card';
+export { TrackList } from './track-list';
+export { DownloadItem } from './download-item';
+export { SearchModal } from './search-modal';
+export { MediaGrid } from './media-grid';

--- a/apps/frontend/src/components/media-card.tsx
+++ b/apps/frontend/src/components/media-card.tsx
@@ -1,0 +1,93 @@
+import { forwardRef, HTMLAttributes } from 'react';
+import Image from 'next/image';
+import { cn } from '@/lib/utils';
+import { mediaStatusColors } from '@/lib/constants';
+import type { Movie, TvShow } from '@/lib/types';
+
+interface MediaCardProps extends HTMLAttributes<HTMLDivElement> {
+  media: Movie | TvShow;
+  onSelect?: () => void;
+}
+
+export const MediaCard = forwardRef<HTMLDivElement, MediaCardProps>(
+  ({ media, onSelect, className, ...props }, ref) => {
+    const posterUrl = media.poster_path
+      ? `https://image.tmdb.org/t/p/w500${media.poster_path}`
+      : '/placeholder-poster.png';
+
+    const year = 'year' in media ? media.year : media.year_start;
+
+    // For movies, show the status indicator; for TV shows, we'll use a different approach
+    const isMovie = 'year' in media;
+    const mediaStatus = isMovie ? (media as Movie).status : null;
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+      if ((e.key === 'Enter' || e.key === ' ') && onSelect) {
+        e.preventDefault();
+        onSelect();
+      }
+    };
+
+    return (
+      <div
+        ref={ref}
+        role={onSelect ? 'button' : undefined}
+        tabIndex={onSelect ? 0 : undefined}
+        className={cn(
+          'group relative overflow-hidden rounded-lcars',
+          'bg-lcars-dark transition-all duration-300',
+          onSelect && 'cursor-pointer hover:ring-2 hover:ring-lcars-orange hover:scale-105 focus:outline-none focus:ring-2 focus:ring-lcars-orange',
+          className
+        )}
+        onClick={onSelect}
+        onKeyDown={handleKeyDown}
+        {...props}
+      >
+        {/* Poster Image */}
+        <div className="relative aspect-[2/3] w-full overflow-hidden bg-lcars-black">
+          <Image
+            src={posterUrl}
+            alt={media.title}
+            fill
+            className="object-cover transition-opacity duration-300 group-hover:opacity-80"
+            sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 20vw"
+          />
+
+          {/* Status Indicator - Only for Movies */}
+          {mediaStatus && (
+            <div className="absolute top-2 left-2">
+              <div
+                className={cn(
+                  'h-3 w-3 rounded-full',
+                  mediaStatusColors[mediaStatus]
+                )}
+                title={mediaStatus}
+              />
+            </div>
+          )}
+
+          {/* Monitored Badge */}
+          {media.monitored && (
+            <div className="absolute top-2 right-2">
+              <div className="rounded-lcars bg-lcars-orange px-2 py-1 text-xs font-bold text-lcars-black">
+                MONITORED
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Info Overlay */}
+        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-lcars-black via-lcars-black/80 to-transparent p-3">
+          <h3 className="truncate text-sm font-bold text-lcars-text">
+            {media.title}
+          </h3>
+          {year && (
+            <p className="text-xs text-lcars-text-dim">{year}</p>
+          )}
+        </div>
+      </div>
+    );
+  }
+);
+
+MediaCard.displayName = 'MediaCard';

--- a/apps/frontend/src/components/media-grid.tsx
+++ b/apps/frontend/src/components/media-grid.tsx
@@ -1,0 +1,27 @@
+import { forwardRef, HTMLAttributes, ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+interface MediaGridProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export const MediaGrid = forwardRef<HTMLDivElement, MediaGridProps>(
+  ({ children, className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'grid gap-4',
+          // Responsive columns: 2 on mobile, 3 on sm, 4 on md, 5 on lg, 6 on xl
+          'grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6',
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+MediaGrid.displayName = 'MediaGrid';

--- a/apps/frontend/src/components/search-modal.tsx
+++ b/apps/frontend/src/components/search-modal.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import { useState, useEffect, useCallback, forwardRef, HTMLAttributes } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import Image from 'next/image';
+import { Search, X, Plus, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { api } from '@/lib/api';
+import { LcarsButton } from '@/components/lcars/button';
+import type {
+  TmdbMovieSearchResult,
+  TmdbTvSearchResult,
+  MusicBrainzArtistSearchResult,
+  MusicBrainzAlbumSearchResult,
+} from '@/lib/types';
+
+type SearchType = 'movie' | 'tv' | 'artist' | 'album';
+type SearchResult =
+  | TmdbMovieSearchResult
+  | TmdbTvSearchResult
+  | MusicBrainzArtistSearchResult
+  | MusicBrainzAlbumSearchResult;
+
+interface SearchModalProps extends HTMLAttributes<HTMLDivElement> {
+  isOpen: boolean;
+  onClose: () => void;
+  searchType: SearchType;
+  onAdd: (result: SearchResult) => void;
+}
+
+export const SearchModal = forwardRef<HTMLDivElement, SearchModalProps>(
+  ({ isOpen, onClose, searchType, onAdd, className, ...props }, ref) => {
+    const [query, setQuery] = useState('');
+    const [debouncedQuery, setDebouncedQuery] = useState('');
+
+    // Debounce search query (300ms)
+    useEffect(() => {
+      const handler = setTimeout(() => {
+        setDebouncedQuery(query);
+      }, 300);
+
+      return () => {
+        clearTimeout(handler);
+      };
+    }, [query]);
+
+    // Handle Escape key to close modal
+    useEffect(() => {
+      const handleEscape = (e: KeyboardEvent) => {
+        if (e.key === 'Escape' && isOpen) {
+          onClose();
+        }
+      };
+
+      document.addEventListener('keydown', handleEscape);
+      return () => {
+        document.removeEventListener('keydown', handleEscape);
+      };
+    }, [isOpen, onClose]);
+
+    // Search query
+    const { data: results = [], isLoading } = useQuery({
+      queryKey: ['search', searchType, debouncedQuery],
+      queryFn: async () => {
+        if (!debouncedQuery.trim()) return [];
+
+        switch (searchType) {
+          case 'movie':
+            return api.searchTmdbMovies(debouncedQuery);
+          case 'tv':
+            return api.searchTmdbTv(debouncedQuery);
+          case 'artist':
+            return api.searchMusicBrainzArtists(debouncedQuery);
+          case 'album':
+            return api.searchMusicBrainzAlbums(debouncedQuery);
+          default:
+            return [];
+        }
+      },
+      enabled: isOpen && debouncedQuery.length > 0,
+    });
+
+    const handleAdd = useCallback((result: SearchResult) => {
+      onAdd(result);
+      setQuery('');
+      setDebouncedQuery('');
+    }, [onAdd]);
+
+    if (!isOpen) return null;
+
+    return (
+      <>
+        {/* Backdrop */}
+        <div
+          className="fixed inset-0 z-40 bg-lcars-black/80 backdrop-blur-sm"
+          onClick={onClose}
+        />
+
+        {/* Modal */}
+        <div
+          ref={ref}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="search-modal-title"
+          className={cn(
+            'fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2',
+            'max-h-[80vh] overflow-hidden rounded-lcars bg-lcars-dark shadow-xl',
+            className
+          )}
+          {...props}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-lcars-orange p-4">
+            <h2 id="search-modal-title" className="text-lg font-bold text-lcars-orange">
+              SEARCH {searchType.toUpperCase()}
+            </h2>
+            <LcarsButton variant="red" size="sm" onClick={onClose}>
+              <X className="h-5 w-5" />
+            </LcarsButton>
+          </div>
+
+          {/* Search Input */}
+          <div className="border-b border-lcars-orange/30 p-4">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-lcars-text-dim" />
+              <input
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={`Search for ${searchType}...`}
+                className={cn(
+                  'w-full rounded-lcars bg-lcars-black py-3 pl-10 pr-4',
+                  'font-lcars text-lcars-text uppercase tracking-wider',
+                  'placeholder:text-lcars-text-dim placeholder:normal-case',
+                  'focus:outline-none focus:ring-2 focus:ring-lcars-orange'
+                )}
+                autoFocus
+              />
+              {isLoading && (
+                <Loader2 className="absolute right-3 top-1/2 h-5 w-5 -translate-y-1/2 animate-spin text-lcars-orange" />
+              )}
+            </div>
+          </div>
+
+          {/* Results */}
+          <div className="max-h-96 overflow-y-auto p-4" aria-live="polite">
+            {!debouncedQuery ? (
+              <div className="py-8 text-center text-sm text-lcars-text-dim">
+                Enter a search query to begin
+              </div>
+            ) : results.length === 0 && !isLoading ? (
+              <div className="py-8 text-center text-sm text-lcars-text-dim">
+                No results found
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {results.map((result) => (
+                  <SearchResultItem
+                    key={'id' in result ? result.id : (result as MusicBrainzArtistSearchResult | MusicBrainzAlbumSearchResult).id}
+                    result={result}
+                    searchType={searchType}
+                    onAdd={() => handleAdd(result)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </>
+    );
+  }
+);
+
+SearchModal.displayName = 'SearchModal';
+
+// Result Item Component
+interface SearchResultItemProps {
+  result: SearchResult;
+  searchType: SearchType;
+  onAdd: () => void;
+}
+
+function SearchResultItem({ result, searchType, onAdd }: SearchResultItemProps) {
+  const getImageUrl = () => {
+    if (searchType === 'movie' || searchType === 'tv') {
+      const tmdbResult = result as TmdbMovieSearchResult | TmdbTvSearchResult;
+      return tmdbResult.poster_path
+        ? `https://image.tmdb.org/t/p/w200${tmdbResult.poster_path}`
+        : null;
+    }
+    return null;
+  };
+
+  const getTitle = () => {
+    if ('title' in result) return result.title;
+    if ('name' in result) return result.name;
+    return 'Unknown';
+  };
+
+  const getSubtitle = () => {
+    if (searchType === 'movie') {
+      const movie = result as TmdbMovieSearchResult;
+      return movie.release_date ? new Date(movie.release_date).getFullYear() : null;
+    }
+    if (searchType === 'tv') {
+      const tv = result as TmdbTvSearchResult;
+      return tv.first_air_date ? new Date(tv.first_air_date).getFullYear() : null;
+    }
+    if (searchType === 'artist') {
+      const artist = result as MusicBrainzArtistSearchResult;
+      return artist.disambiguation || artist.country || null;
+    }
+    if (searchType === 'album') {
+      const album = result as MusicBrainzAlbumSearchResult;
+      return album.artist_credit || null;
+    }
+    return null;
+  };
+
+  const imageUrl = getImageUrl();
+  const title = getTitle();
+  const subtitle = getSubtitle();
+
+  return (
+    <div className="flex items-center gap-3 rounded-lcars bg-lcars-black p-3 transition-colors hover:bg-lcars-orange/10">
+      {/* Poster/Image */}
+      {imageUrl ? (
+        <div className="relative h-16 w-12 shrink-0 overflow-hidden rounded">
+          <Image
+            src={imageUrl}
+            alt={title}
+            fill
+            className="object-cover"
+            sizes="48px"
+          />
+        </div>
+      ) : (
+        <div className="flex h-16 w-12 shrink-0 items-center justify-center rounded bg-lcars-dark">
+          <Search className="h-6 w-6 text-lcars-text-dim" />
+        </div>
+      )}
+
+      {/* Info */}
+      <div className="flex-1">
+        <h3 className="text-sm font-bold text-lcars-text">{title}</h3>
+        {subtitle && (
+          <p className="mt-1 text-xs text-lcars-text-dim">{subtitle}</p>
+        )}
+      </div>
+
+      {/* Add Button */}
+      <LcarsButton variant="orange" size="sm" onClick={onAdd}>
+        <Plus className="h-4 w-4" />
+        <span className="ml-1">Add</span>
+      </LcarsButton>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/track-list.tsx
+++ b/apps/frontend/src/components/track-list.tsx
@@ -1,0 +1,115 @@
+import { forwardRef, HTMLAttributes, useMemo } from 'react';
+import { cn } from '@/lib/utils';
+import { mediaStatusColors } from '@/lib/constants';
+import type { Track } from '@/lib/types';
+
+interface TrackListProps extends HTMLAttributes<HTMLDivElement> {
+  tracks: Track[];
+  onTrackClick?: (track: Track) => void;
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
+}
+
+export const TrackList = forwardRef<HTMLDivElement, TrackListProps>(
+  ({ tracks, onTrackClick, className, ...props }, ref) => {
+    // Group tracks by disc number - memoized to avoid recalculation
+    const { tracksByDisc, discs } = useMemo(() => {
+      const grouped = tracks.reduce((acc, track) => {
+        const disc = track.disc_number;
+        if (!acc[disc]) {
+          acc[disc] = [];
+        }
+        acc[disc].push(track);
+        return acc;
+      }, {} as Record<number, Track[]>);
+
+      const sortedDiscs = Object.keys(grouped)
+        .map(Number)
+        .sort((a, b) => a - b);
+
+      return { tracksByDisc: grouped, discs: sortedDiscs };
+    }, [tracks]);
+
+    // Empty state
+    if (tracks.length === 0) {
+      return (
+        <div ref={ref} className={cn('space-y-4', className)} {...props}>
+          <div className="py-8 text-center text-sm text-lcars-text-dim">
+            No tracks available
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div ref={ref} className={cn('space-y-4', className)} {...props}>
+        {discs.map((discNumber) => {
+          const discTracks = tracksByDisc[discNumber].sort(
+            (a, b) => a.track_number - b.track_number
+          );
+
+          return (
+            <div key={discNumber} className="space-y-1">
+              {/* Disc Header (only show if multiple discs) */}
+              {discs.length > 1 && (
+                <div className="mb-2 border-b border-lcars-orange pb-1">
+                  <h3 className="text-sm font-bold text-lcars-orange">
+                    DISC {discNumber}
+                  </h3>
+                </div>
+              )}
+
+              {/* Track List */}
+              {discTracks.map((track) => (
+                <div
+                  key={track.id}
+                  className={cn(
+                    'group flex items-center justify-between rounded-lcars px-3 py-2',
+                    'bg-lcars-dark transition-all duration-200',
+                    onTrackClick && 'cursor-pointer hover:bg-lcars-orange/20 hover:ring-1 hover:ring-lcars-orange'
+                  )}
+                  onClick={() => onTrackClick?.(track)}
+                >
+                  <div className="flex flex-1 items-center gap-3">
+                    {/* Status Indicator */}
+                    <div
+                      className={cn(
+                        'h-2 w-2 shrink-0 rounded-full',
+                        mediaStatusColors[track.status]
+                      )}
+                      title={track.status}
+                    />
+
+                    {/* Track Number */}
+                    <span className="w-8 shrink-0 text-sm text-lcars-text-dim">
+                      {track.track_number}
+                    </span>
+
+                    {/* Track Title */}
+                    <span className="flex-1 truncate text-sm text-lcars-text">
+                      {track.title}
+                    </span>
+                  </div>
+
+                  {/* Duration */}
+                  {track.duration_ms && (
+                    <span className="shrink-0 text-sm text-lcars-text-dim">
+                      {formatDuration(track.duration_ms)}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+);
+
+TrackList.displayName = 'TrackList';

--- a/apps/frontend/src/lib/constants.ts
+++ b/apps/frontend/src/lib/constants.ts
@@ -1,0 +1,25 @@
+import type { MediaStatus, DownloadStatus } from '@/lib/types';
+
+/**
+ * Color mappings for media status indicators
+ */
+export const mediaStatusColors: Record<MediaStatus, string> = {
+  available: 'bg-status-available',
+  downloading: 'bg-status-downloading',
+  processing: 'bg-status-processing',
+  missing: 'bg-status-missing',
+  searching: 'bg-lcars-yellow',
+};
+
+/**
+ * Color mappings for download status indicators
+ */
+export const downloadStatusColors: Record<DownloadStatus, string> = {
+  queued: 'bg-lcars-yellow',
+  downloading: 'bg-status-downloading',
+  seeding: 'bg-status-available',
+  processing: 'bg-status-processing',
+  completed: 'bg-status-available',
+  failed: 'bg-status-missing',
+  paused: 'bg-lcars-tan',
+};

--- a/apps/frontend/src/lib/utils.ts
+++ b/apps/frontend/src/lib/utils.ts
@@ -19,3 +19,7 @@ export function formatDuration(seconds: number): string {
   if (h > 0) return `${h}h ${m}m`;
   return `${m}m`;
 }
+
+export function formatSpeed(bytesPerSecond: number): string {
+  return `${formatBytes(bytesPerSecond)}/s`;
+}


### PR DESCRIPTION
## Summary

- Add reusable media components for displaying movies, TV shows, artists, albums, and tracks
- Create `MediaCard`, `ArtistCard`, `TrackList`, `DownloadItem`, `SearchModal`, and `MediaGrid` components
- All components follow LCARS design system with proper styling and accessibility

## Components

| Component | Description |
|-----------|-------------|
| `MediaCard` | Movie/TV show cards with poster, status indicator, monitoring badge |
| `ArtistCard` | Music artist cards with album count and disambiguation text |
| `TrackList` | Album track listing with disc grouping and status colors |
| `DownloadItem` | Download progress display with pause/resume/cancel controls |
| `SearchModal` | TMDB/MusicBrainz search modal with debounced input |
| `MediaGrid` | Responsive grid layout (2-6 columns based on viewport) |

## Additional Changes

- Created shared `constants.ts` with status color maps
- Added `formatSpeed` helper to utils
- Barrel export in `components/index.ts`

## Accessibility

- Keyboard navigation support (Enter/Space for interactive cards)
- ARIA attributes for modal (`role="dialog"`, `aria-modal`, `aria-labelledby`)
- Escape key closes modal
- Focus styles for keyboard users
- Screen reader announcements for search results

## Test plan

- [x] `moon run frontend:typecheck` passes
- [x] `moon run frontend:lint` passes  
- [x] `moon run frontend:build` succeeds
- [ ] Visual review of components in browser
- [ ] Keyboard navigation testing
- [ ] Screen reader testing

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)