### PR TITLE
feat(backend): add Soulseek download initiation and browse API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]

--- a/apps/backend/Cargo.toml
+++ b/apps/backend/Cargo.toml
@@ -40,6 +40,7 @@ tokio-cron-scheduler = "0.13"
 tower-http = { version = "0.5", features = ["cors"] }
 soulseek-protocol = { path = "../../packages/soulseek-protocol" }
 bytes = "1.5"
+uuid = { version = "1.19.0", features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/apps/backend/src/services/soulseek/engine.rs
+++ b/apps/backend/src/services/soulseek/engine.rs
@@ -5,28 +5,43 @@
 
 use rand::Rng;
 use soulseek_protocol::{
-    peers::p2p::search::SearchReply,
+    message_common::ConnectionType,
+    peers::p2p::{
+        response::PeerResponse, search::SearchReply, shared_directories::SharedDirectories,
+    },
     server::{
-        login::LoginRequest, request::ServerRequest, response::ServerResponse,
-        search::SearchRequest,
+        login::LoginRequest, peer::RequestConnectionToPeer, request::ServerRequest,
+        response::ServerResponse, search::SearchRequest,
     },
 };
 use std::collections::HashMap;
+use std::net::Ipv4Addr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tokio::sync::{broadcast, mpsc, RwLock};
+use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
+use uuid::Uuid;
 
 use crate::config::SoulseekConfig;
 use crate::error::{AppError, Result};
 
 use super::connection::SoulseekConnection;
 use super::events::SoulseekEvent;
-use super::types::{FileResult, SearchResult, SearchState, SoulseekStats};
+use super::peer::PeerConnection;
+use super::types::{
+    BrowsedDirectory, BrowsedFile, DownloadRequest, DownloadState, DownloadStatus, FileResult,
+    SearchResult, SearchState, SoulseekStats,
+};
+
+/// Pending peer address request - waiting for server to provide IP/port.
+struct PendingPeerAddress {
+    /// Channel to send the result back.
+    tx: oneshot::Sender<Result<(Ipv4Addr, u32)>>,
+}
 
 /// Soulseek client engine.
 ///
 /// Manages connection to the Soulseek server and provides search functionality.
-/// P2P file transfers will be added in a future phase.
+/// Also handles P2P connections for browsing and downloading.
 pub struct SoulseekEngine {
     /// Configuration.
     config: SoulseekConfig,
@@ -36,10 +51,14 @@ pub struct SoulseekEngine {
     event_tx: broadcast::Sender<SoulseekEvent>,
     /// Active searches indexed by ticket.
     searches: Arc<RwLock<HashMap<u32, SearchState>>>,
+    /// Active downloads indexed by ID.
+    downloads: Arc<RwLock<HashMap<String, DownloadState>>>,
     /// Connection status flag.
     connected: AtomicBool,
     /// Username we logged in with.
     username: Arc<RwLock<Option<String>>>,
+    /// Pending peer address requests indexed by username.
+    pending_peer_addresses: Arc<RwLock<HashMap<String, PendingPeerAddress>>>,
 }
 
 impl SoulseekEngine {
@@ -64,8 +83,10 @@ impl SoulseekEngine {
             connection: Arc::new(RwLock::new(None)),
             event_tx,
             searches: Arc::new(RwLock::new(HashMap::new())),
+            downloads: Arc::new(RwLock::new(HashMap::new())),
             connected: AtomicBool::new(false),
             username: Arc::new(RwLock::new(None)),
+            pending_peer_addresses: Arc::new(RwLock::new(HashMap::new())),
         })
     }
 
@@ -217,12 +238,199 @@ impl SoulseekEngine {
         let searches = self.searches.read().await;
         let active_searches = searches.values().filter(|s| !s.complete).count();
 
+        let downloads = self.downloads.read().await;
+        let active_downloads = downloads
+            .values()
+            .filter(|d| {
+                matches!(
+                    d.status,
+                    DownloadStatus::Connecting
+                        | DownloadStatus::Queued
+                        | DownloadStatus::Downloading
+                )
+            })
+            .count();
+        let completed_downloads = downloads
+            .values()
+            .filter(|d| d.status == DownloadStatus::Completed)
+            .count();
+
         SoulseekStats {
             connected: self.is_connected(),
             active_searches,
-            active_downloads: 0,    // TODO: Phase 3
-            completed_downloads: 0, // TODO: Phase 3
+            active_downloads,
+            completed_downloads,
         }
+    }
+
+    // =========================================================================
+    // Download methods
+    // =========================================================================
+
+    /// Initiate a file download from a peer.
+    ///
+    /// Returns the download ID that can be used to track progress.
+    pub async fn download(&self, request: DownloadRequest) -> Result<String> {
+        if !self.is_connected() {
+            return Err(AppError::ServiceUnavailable(
+                "Not connected to Soulseek server".to_string(),
+            ));
+        }
+
+        // Generate unique download ID and ticket
+        let id = Uuid::new_v4().to_string();
+        let ticket: u32 = rand::thread_rng().gen();
+
+        tracing::info!(
+            id = %id,
+            username = %request.username,
+            filename = %request.filename,
+            ticket = ticket,
+            "Starting Soulseek download"
+        );
+
+        // Create download state
+        let mut download_state = DownloadState::new(
+            id.clone(),
+            request.username.clone(),
+            request.filename.clone(),
+            request.size,
+            ticket,
+        );
+        download_state.media_type = request.media_type.clone();
+        download_state.media_id = request.media_id;
+
+        // Store download state
+        {
+            let mut downloads = self.downloads.write().await;
+            downloads.insert(id.clone(), download_state);
+        }
+
+        // Emit event
+        let _ = self.event_tx.send(SoulseekEvent::DownloadQueued {
+            id: id.clone(),
+            username: request.username.clone(),
+            filename: request.filename.clone(),
+        });
+
+        // Request peer address from server
+        let connect_req =
+            RequestConnectionToPeer::new(request.username.clone(), ConnectionType::PeerToPeer);
+        self.send_request(ServerRequest::ConnectToPeer(connect_req))
+            .await?;
+
+        Ok(id)
+    }
+
+    /// Get the current state of a download.
+    pub async fn get_download(&self, id: &str) -> Option<DownloadState> {
+        let downloads = self.downloads.read().await;
+        downloads.get(id).cloned()
+    }
+
+    /// Get all downloads.
+    pub async fn get_downloads(&self) -> Vec<DownloadState> {
+        let downloads = self.downloads.read().await;
+        downloads.values().cloned().collect()
+    }
+
+    /// Cancel an active download.
+    pub async fn cancel_download(&self, id: &str) -> Result<()> {
+        let mut downloads = self.downloads.write().await;
+        if let Some(download) = downloads.get_mut(id) {
+            download.status = DownloadStatus::Cancelled;
+            tracing::debug!(id = %id, "Cancelled Soulseek download");
+            Ok(())
+        } else {
+            Err(AppError::NotFound(format!(
+                "Download with ID {} not found",
+                id
+            )))
+        }
+    }
+
+    // =========================================================================
+    // Browse methods
+    // =========================================================================
+
+    /// Browse a user's shared files.
+    ///
+    /// Connects directly to the peer and retrieves their shared file list.
+    pub async fn browse_user(&self, username: &str) -> Result<Vec<BrowsedDirectory>> {
+        if !self.is_connected() {
+            return Err(AppError::ServiceUnavailable(
+                "Not connected to Soulseek server".to_string(),
+            ));
+        }
+
+        tracing::info!(username = %username, "Browsing user's shares");
+
+        // Get peer address from server
+        let (ip, port) = self.get_peer_address(username).await?;
+
+        // Get our username
+        let our_username = {
+            let username_guard = self.username.read().await;
+            username_guard
+                .clone()
+                .ok_or_else(|| AppError::Internal("Not logged in".to_string()))?
+        };
+
+        // Generate connection token
+        let token: u32 = rand::thread_rng().gen();
+
+        // Connect to peer
+        let (mut peer_conn, mut message_rx) =
+            PeerConnection::connect(username, ip, port, &our_username, token).await?;
+
+        // Request shares
+        peer_conn.request_shares().await?;
+
+        // Wait for shares reply with timeout
+        let shares = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+            while let Some(msg) = message_rx.recv().await {
+                if let PeerResponse::SharesReply(dirs) = msg {
+                    return Ok(dirs);
+                }
+            }
+            Err(AppError::Internal(
+                "Peer disconnected before sending shares".to_string(),
+            ))
+        })
+        .await
+        .map_err(|_| {
+            AppError::Internal(format!("Timeout waiting for shares from {}", username))
+        })??;
+
+        // Shutdown peer connection
+        peer_conn.shutdown().await;
+
+        // Convert to our format
+        Ok(convert_shared_directories(shares))
+    }
+
+    /// Get the address (IP and port) of a peer from the server.
+    async fn get_peer_address(&self, username: &str) -> Result<(Ipv4Addr, u32)> {
+        // Create a channel to receive the address
+        let (tx, rx) = oneshot::channel();
+
+        // Register the pending request
+        {
+            let mut pending = self.pending_peer_addresses.write().await;
+            pending.insert(username.to_string(), PendingPeerAddress { tx });
+        }
+
+        // Request the address from server
+        self.send_request(ServerRequest::GetPeerAddress(username.to_string()))
+            .await?;
+
+        // Wait for response with timeout
+        tokio::time::timeout(std::time::Duration::from_secs(10), rx)
+            .await
+            .map_err(|_| {
+                AppError::Internal(format!("Timeout waiting for peer address for {}", username))
+            })?
+            .map_err(|_| AppError::Internal("Peer address request cancelled".to_string()))?
     }
 
     /// Gracefully stop the engine.
@@ -338,6 +546,33 @@ impl SoulseekEngine {
                 self.handle_embedded_message(embedded).await?;
             }
 
+            ServerResponse::PeerAddress(peer_address) => {
+                tracing::debug!(
+                    username = %peer_address.username,
+                    ip = %peer_address.ip,
+                    port = peer_address.port,
+                    "Received peer address"
+                );
+
+                // Complete the pending request
+                let mut pending = self.pending_peer_addresses.write().await;
+                if let Some(request) = pending.remove(&peer_address.username) {
+                    let _ = request.tx.send(Ok((peer_address.ip, peer_address.port)));
+                }
+            }
+
+            ServerResponse::PeerConnectionRequest(connection_request) => {
+                tracing::debug!(
+                    username = %connection_request.username,
+                    ip = %connection_request.ip,
+                    port = connection_request.port,
+                    token = connection_request.token,
+                    "Received peer connection request"
+                );
+                // For now, we don't handle incoming connections
+                // This would be needed for users trying to download from us
+            }
+
             ServerResponse::Unknown(len, code, _data) => {
                 tracing::trace!(code = code, len = len, "Received unknown message");
             }
@@ -402,6 +637,61 @@ impl SoulseekEngine {
             queue_length: reply.queue_length,
         });
     }
+}
+
+/// Convert protocol SharedDirectories to our BrowsedDirectory format.
+fn convert_shared_directories(dirs: SharedDirectories) -> Vec<BrowsedDirectory> {
+    dirs.dirs
+        .into_iter()
+        .map(|dir| {
+            let files: Vec<BrowsedFile> = dir
+                .files
+                .into_iter()
+                .map(|file| {
+                    // Extract attributes
+                    let mut bitrate = None;
+                    let mut duration = None;
+
+                    for attr in &file.attributes {
+                        match attr.place {
+                            0 => bitrate = Some(attr.attribute),
+                            1 => duration = Some(attr.attribute),
+                            _ => {}
+                        }
+                    }
+
+                    // Get filename from full path
+                    let name = file
+                        .name
+                        .rsplit(['/', '\\'])
+                        .next()
+                        .unwrap_or(&file.name)
+                        .to_string();
+
+                    let extension = if !file.extension.is_empty() {
+                        file.extension.to_lowercase()
+                    } else {
+                        name.rsplit('.').next().unwrap_or("").to_lowercase()
+                    };
+
+                    BrowsedFile {
+                        name,
+                        full_path: file.name,
+                        size: file.size,
+                        extension,
+                        bitrate,
+                        duration,
+                    }
+                })
+                .collect();
+
+            BrowsedDirectory {
+                path: dir.name,
+                file_count: files.len(),
+                files,
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/apps/backend/src/services/soulseek/mod.rs
+++ b/apps/backend/src/services/soulseek/mod.rs
@@ -7,8 +7,13 @@
 mod connection;
 mod engine;
 mod events;
+mod peer;
 mod types;
 
 pub use engine::SoulseekEngine;
 pub use events::SoulseekEvent;
-pub use types::{FileResult, SearchResult, SearchState, SoulseekStats};
+pub use peer::{BrowseResult, PeerConnection};
+pub use types::{
+    BrowsedDirectory, BrowsedFile, DownloadRequest, DownloadState, DownloadStatus, FileResult,
+    SearchResult, SearchState, SoulseekStats,
+};

--- a/apps/backend/src/services/soulseek/peer.rs
+++ b/apps/backend/src/services/soulseek/peer.rs
@@ -1,0 +1,282 @@
+//! Peer-to-peer connection handling for Soulseek file transfers.
+//!
+//! This module manages direct connections to Soulseek peers for browsing
+//! shared directories and downloading files.
+
+use bytes::{Buf, BytesMut};
+use soulseek_protocol::{
+    frame::ToBytes,
+    message_common::ConnectionType,
+    peers::{
+        connection::PeerConnectionMessage,
+        p2p::{
+            folder_content::FolderContentsRequest, request::PeerRequest, response::PeerResponse,
+            shared_directories::SharedDirectories, PeerMessageCode, PeerMessageHeader,
+        },
+    },
+    ProtocolHeader, ProtocolMessage,
+};
+use std::io::Cursor;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufWriter};
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::TcpStream;
+use tokio::sync::{mpsc, oneshot, Mutex};
+
+use crate::error::{AppError, Result};
+
+/// Buffer size for reading from peer connections.
+const READ_BUFFER_SIZE: usize = 65536;
+
+/// Connection timeout for peer connections.
+const CONNECT_TIMEOUT_SECS: u64 = 30;
+
+/// A connection to a Soulseek peer.
+///
+/// Handles P2P protocol communication for browsing files and downloading.
+pub struct PeerConnection {
+    /// Username of the peer.
+    pub username: String,
+    /// Writer half of the TCP connection.
+    writer: Arc<Mutex<BufWriter<OwnedWriteHalf>>>,
+    /// Channel to signal shutdown to the read loop.
+    shutdown_tx: Option<oneshot::Sender<()>>,
+}
+
+impl PeerConnection {
+    /// Connect to a peer using the server-provided connection info.
+    ///
+    /// This establishes a direct TCP connection to the peer.
+    pub async fn connect(
+        username: &str,
+        ip: std::net::Ipv4Addr,
+        port: u32,
+        our_username: &str,
+        token: u32,
+    ) -> Result<(Self, mpsc::Receiver<PeerResponse>)> {
+        let addr = format!("{}:{}", ip, port);
+        tracing::debug!(
+            addr = %addr,
+            username = %username,
+            token = token,
+            "Connecting to peer"
+        );
+
+        // Connect with timeout
+        let stream = tokio::time::timeout(
+            std::time::Duration::from_secs(CONNECT_TIMEOUT_SECS),
+            TcpStream::connect(&addr),
+        )
+        .await
+        .map_err(|_| {
+            AppError::ServiceUnavailable(format!("Connection to peer {} timed out", username))
+        })?
+        .map_err(|e| {
+            AppError::ServiceUnavailable(format!("Failed to connect to peer {}: {}", username, e))
+        })?;
+
+        let (reader, writer) = stream.into_split();
+        let writer = Arc::new(Mutex::new(BufWriter::new(writer)));
+
+        // Create channel for incoming messages
+        let (message_tx, message_rx) = mpsc::channel(100);
+
+        // Create shutdown signal
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+        // Send PeerInit message to identify ourselves
+        {
+            let mut w = writer.lock().await;
+            let init = PeerConnectionMessage::PeerInit {
+                username: our_username.to_string(),
+                connection_type: ConnectionType::PeerToPeer,
+                token,
+            };
+            init.write_to_buf(&mut *w)
+                .await
+                .map_err(|e| AppError::Internal(format!("Failed to send PeerInit: {}", e)))?;
+            w.flush()
+                .await
+                .map_err(|e| AppError::Internal(format!("Failed to flush writer: {}", e)))?;
+        }
+
+        // Spawn the read loop
+        let username_clone = username.to_string();
+        tokio::spawn(Self::read_loop(
+            reader,
+            message_tx,
+            shutdown_rx,
+            username_clone,
+        ));
+
+        tracing::info!(addr = %addr, username = %username, "Connected to peer");
+
+        Ok((
+            Self {
+                username: username.to_string(),
+                writer,
+                shutdown_tx: Some(shutdown_tx),
+            },
+            message_rx,
+        ))
+    }
+
+    /// Send a peer request.
+    pub async fn send(&self, request: PeerRequest) -> Result<()> {
+        let mut writer = self.writer.lock().await;
+        request
+            .write_to_buf(&mut *writer)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to write peer request: {}", e)))?;
+        writer
+            .flush()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to flush writer: {}", e)))?;
+        Ok(())
+    }
+
+    /// Request the peer's shared directories.
+    pub async fn request_shares(&self) -> Result<()> {
+        self.send(PeerRequest::SharesRequest).await
+    }
+
+    /// Request folder contents for specific directories.
+    pub async fn request_folder_contents(&self, folders: Vec<String>) -> Result<()> {
+        self.send(PeerRequest::FolderContentsRequest(FolderContentsRequest {
+            files: folders,
+        }))
+        .await
+    }
+
+    /// Shutdown the connection gracefully.
+    pub async fn shutdown(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+    }
+
+    /// Background task that reads from the peer and parses messages.
+    async fn read_loop(
+        mut reader: OwnedReadHalf,
+        message_tx: mpsc::Sender<PeerResponse>,
+        mut shutdown_rx: oneshot::Receiver<()>,
+        username: String,
+    ) {
+        let mut buffer = BytesMut::with_capacity(READ_BUFFER_SIZE);
+
+        loop {
+            tokio::select! {
+                _ = &mut shutdown_rx => {
+                    tracing::debug!(username = %username, "Peer read loop received shutdown signal");
+                    break;
+                }
+                result = reader.read_buf(&mut buffer) => {
+                    match result {
+                        Ok(0) => {
+                            tracing::info!(username = %username, "Peer closed connection");
+                            break;
+                        }
+                        Ok(n) => {
+                            tracing::trace!(username = %username, bytes = n, "Received data from peer");
+
+                            // Try to parse messages from buffer
+                            while let Some(response) = Self::try_parse_message(&mut buffer) {
+                                match response {
+                                    Ok(msg) => {
+                                        tracing::trace!(username = %username, ?msg, "Parsed peer message");
+                                        if message_tx.send(msg).await.is_err() {
+                                            tracing::debug!(username = %username, "Message receiver dropped");
+                                            return;
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            username = %username,
+                                            error = %e,
+                                            "Failed to parse peer message"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!(username = %username, error = %e, "Error reading from peer");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        tracing::debug!(username = %username, "Peer read loop terminated");
+    }
+
+    /// Try to parse a complete message from the buffer.
+    fn try_parse_message(
+        buffer: &mut BytesMut,
+    ) -> Option<std::result::Result<PeerResponse, std::io::Error>> {
+        // Need at least 8 bytes for header (4 length + 4 code)
+        if buffer.len() < 8 {
+            return None;
+        }
+
+        // Peek at the message length without consuming
+        let msg_len = u32::from_le_bytes([buffer[0], buffer[1], buffer[2], buffer[3]]) as usize;
+
+        // Check if we have the complete message
+        if buffer.len() < 4 + msg_len {
+            return None;
+        }
+
+        // We have a complete message, parse it
+        let msg_data = buffer.split_to(4 + msg_len);
+        let mut cursor = Cursor::new(msg_data.as_ref());
+
+        // Skip the length prefix we already read
+        cursor.set_position(4);
+
+        // Read the message code
+        let code = cursor.get_u32_le();
+        let peer_code = PeerMessageCode::from(code);
+
+        // Create header manually
+        let header = PeerMessageHeader::new(msg_len - 4, peer_code);
+
+        // Parse the message
+        Some(PeerResponse::parse(&mut cursor, &header))
+    }
+}
+
+impl Drop for PeerConnection {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+/// Result of browsing a peer's shared files.
+#[derive(Debug, Clone)]
+pub struct BrowseResult {
+    /// Username of the peer.
+    pub username: String,
+    /// Shared directories and files.
+    pub directories: SharedDirectories,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_parse_message_incomplete() {
+        let mut buffer = BytesMut::from(&[0u8, 0, 0, 0][..]);
+        assert!(PeerConnection::try_parse_message(&mut buffer).is_none());
+    }
+
+    #[test]
+    fn test_try_parse_message_partial() {
+        let mut buffer = BytesMut::from(&[10u8, 0, 0, 0, 1, 2, 3][..]); // Says 10 bytes but only 3 present
+        assert!(PeerConnection::try_parse_message(&mut buffer).is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- Add REST API endpoints for Soulseek downloads and user file browsing
- Implement P2P peer connection handling for direct peer communication
- Add download state tracking and browse result types

## New Endpoints
- `POST /api/soulseek/download` - Initiate file download from a peer
- `GET /api/soulseek/downloads` - List all Soulseek downloads  
- `GET /api/soulseek/downloads/{id}` - Get specific download status
- `DELETE /api/soulseek/downloads/{id}` - Cancel a download
- `GET /api/soulseek/browse/{username}` - Browse peer's shared files

## Implementation
- **peer.rs**: New module for P2P connection handling with proper protocol initialization
- **types.rs**: Added DownloadState, DownloadStatus, BrowsedDirectory, BrowsedFile types
- **engine.rs**: Added download(), browse_user(), get_downloads() methods with peer address resolution
- **soulseek.rs (API)**: Added download and browse endpoint handlers

## Test plan
- [ ] Verify unit tests pass (108 tests)
- [ ] Verify clippy passes with no warnings
- [ ] Verify integration with existing Soulseek search API

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)