### PR TITLE
feat(backend): add Soulseek connection management and auto-reconnect

### DIFF
--- a/apps/backend/src/config.rs
+++ b/apps/backend/src/config.rs
@@ -222,6 +222,17 @@ pub struct SoulseekConfig {
     pub upload_speed_limit: Option<u64>,
     #[serde(default)]
     pub sharing_enabled: bool,
+    // Connection management
+    #[serde(default = "default_auto_reconnect")]
+    pub auto_reconnect: bool,
+    #[serde(default = "default_connect_timeout")]
+    pub connect_timeout: u64,
+    #[serde(default)]
+    pub max_reconnect_attempts: Option<u32>,
+    #[serde(default = "default_reconnect_delay_max")]
+    pub reconnect_delay_max: u64,
+    #[serde(default = "default_keepalive_interval")]
+    pub keepalive_interval: u64,
 }
 
 // Custom Debug implementation to avoid exposing password
@@ -240,6 +251,11 @@ impl std::fmt::Debug for SoulseekConfig {
             .field("upload_slots", &self.upload_slots)
             .field("upload_speed_limit", &self.upload_speed_limit)
             .field("sharing_enabled", &self.sharing_enabled)
+            .field("auto_reconnect", &self.auto_reconnect)
+            .field("connect_timeout", &self.connect_timeout)
+            .field("max_reconnect_attempts", &self.max_reconnect_attempts)
+            .field("reconnect_delay_max", &self.reconnect_delay_max)
+            .field("keepalive_interval", &self.keepalive_interval)
             .finish()
     }
 }
@@ -259,6 +275,11 @@ impl Default for SoulseekConfig {
             upload_slots: default_upload_slots(),
             upload_speed_limit: None,
             sharing_enabled: false,
+            auto_reconnect: default_auto_reconnect(),
+            connect_timeout: default_connect_timeout(),
+            max_reconnect_attempts: None,
+            reconnect_delay_max: default_reconnect_delay_max(),
+            keepalive_interval: default_keepalive_interval(),
         }
     }
 }
@@ -285,6 +306,22 @@ fn default_max_concurrent_downloads() -> usize {
 
 fn default_upload_slots() -> u32 {
     5
+}
+
+fn default_auto_reconnect() -> bool {
+    true
+}
+
+fn default_connect_timeout() -> u64 {
+    30
+}
+
+fn default_reconnect_delay_max() -> u64 {
+    60
+}
+
+fn default_keepalive_interval() -> u64 {
+    60
 }
 
 /// Storage configuration

--- a/apps/backend/src/services/soulseek/events.rs
+++ b/apps/backend/src/services/soulseek/events.rs
@@ -9,11 +9,34 @@ use super::types::FileResult;
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum SoulseekEvent {
-    /// Successfully connected to the Soulseek server.
-    Connected,
+    // =========================================================================
+    // Connection events
+    // =========================================================================
+    /// Successfully connected and logged in to the Soulseek server.
+    Connected {
+        /// The username that was used to log in.
+        username: String,
+    },
 
     /// Disconnected from the Soulseek server.
-    Disconnected { reason: String },
+    Disconnected {
+        /// Reason for disconnection.
+        reason: String,
+    },
+
+    /// Attempting to reconnect to the server.
+    Reconnecting {
+        /// Current reconnection attempt number.
+        attempt: u32,
+        /// Seconds until next retry.
+        next_retry_secs: u64,
+    },
+
+    /// Connection failed permanently (will not retry).
+    ConnectionFailed {
+        /// Error describing why the connection failed.
+        error: String,
+    },
 
     /// Login attempt failed.
     LoginFailed { reason: String },

--- a/apps/backend/src/services/soulseek/mod.rs
+++ b/apps/backend/src/services/soulseek/mod.rs
@@ -18,7 +18,7 @@ pub use events::SoulseekEvent;
 pub use peer::{BrowseResult, PeerConnection};
 pub use shares::{FileAttributes, ShareIndex, ShareStats, SharedFile};
 pub use types::{
-    BrowsedDirectory, BrowsedFile, DownloadRequest, DownloadState, DownloadStatus, FileResult,
-    SearchResult, SearchState, ShareStatsResponse, SoulseekStats,
+    BrowsedDirectory, BrowsedFile, ConnectionState, DownloadRequest, DownloadState, DownloadStatus,
+    FileResult, SearchResult, SearchState, ShareStatsResponse, SoulseekStats,
 };
 pub use uploads::{UploadQueue, UploadState, UploadStatus};


### PR DESCRIPTION
## Summary

Implements robust connection management for the SoulseekEngine, addressing Issue #49.

- Added `ConnectionState` enum with 6 states: `Disconnected`, `Connecting`, `Authenticating`, `Connected`, `Reconnecting`, `Failed`
- Added configuration options for connection management: `auto_reconnect`, `connect_timeout`, `max_reconnect_attempts`, `reconnect_delay_max`, `keepalive_interval`
- Implemented auto-reconnect with exponential backoff (1s, 2s, 4s, 8s... up to configurable max)
- Added keepalive task that sends periodic status updates to maintain connection
- Added new events: `Reconnecting`, `ConnectionFailed`; updated `Connected` to include username
- Updated API `/api/soulseek/status` response with full connection state details (state, server, username, connected_since, reconnect_attempts)

## Test plan

- [x] Verify `moon ci` passes all tests
- [ ] Manual test: disconnect network and verify reconnection attempts occur with backoff
- [ ] Manual test: verify keepalive messages are sent at configured interval
- [ ] Manual test: verify status API returns connection state details

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)