### PR TITLE
test(backend): add comprehensive Soulseek integration tests

### DIFF
--- a/apps/backend/src/db/mod.rs
+++ b/apps/backend/src/db/mod.rs
@@ -102,4 +102,146 @@ mod tests {
 
         assert_eq!(fk_enabled, 1, "Foreign keys should be enabled");
     }
+
+    #[test]
+    fn test_downloads_table_has_multi_source_columns() {
+        let conn = init_db_memory().expect("Failed to initialize in-memory database");
+
+        // Get column info for downloads table
+        let mut stmt = conn
+            .prepare("PRAGMA table_info(downloads)")
+            .expect("Failed to prepare statement");
+
+        let columns: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+
+        // V004 migration columns
+        assert!(
+            columns.contains(&"source_type".to_string()),
+            "downloads should have source_type column"
+        );
+        assert!(
+            columns.contains(&"source_id".to_string()),
+            "downloads should have source_id column (renamed from info_hash)"
+        );
+        assert!(
+            columns.contains(&"source_uri".to_string()),
+            "downloads should have source_uri column (renamed from magnet)"
+        );
+        assert!(
+            columns.contains(&"soulseek_username".to_string()),
+            "downloads should have soulseek_username column"
+        );
+        assert!(
+            columns.contains(&"soulseek_filename".to_string()),
+            "downloads should have soulseek_filename column"
+        );
+        assert!(
+            columns.contains(&"queue_position".to_string()),
+            "downloads should have queue_position column"
+        );
+    }
+
+    #[test]
+    fn test_downloads_source_type_index_exists() {
+        let conn = init_db_memory().expect("Failed to initialize in-memory database");
+
+        let indexes: Vec<String> = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='downloads'")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+
+        assert!(
+            indexes.contains(&"idx_downloads_source_type".to_string()),
+            "should have index on source_type"
+        );
+        assert!(
+            indexes.contains(&"idx_downloads_source_unique".to_string()),
+            "should have unique index on (source_type, source_id)"
+        );
+    }
+
+    #[test]
+    fn test_can_insert_torrent_download() {
+        let conn = init_db_memory().expect("Failed to initialize in-memory database");
+
+        // Insert a torrent download
+        conn.execute(
+            "INSERT INTO downloads (source_type, source_id, source_uri, name, status, size_bytes, downloaded_bytes, media_type, media_id)
+             VALUES ('torrent', 'abc123hash', 'magnet:?xt=urn:btih:abc123', 'Test Movie', 'downloading', 1000000, 0, 'movie', 1)",
+            [],
+        )
+        .expect("Should be able to insert torrent download");
+
+        let count: i32 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM downloads WHERE source_type = 'torrent'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_can_insert_soulseek_download() {
+        let conn = init_db_memory().expect("Failed to initialize in-memory database");
+
+        // Insert a Soulseek download
+        conn.execute(
+            "INSERT INTO downloads (source_type, source_id, source_uri, name, status, size_bytes, downloaded_bytes, media_type, media_id, soulseek_username, soulseek_filename, queue_position)
+             VALUES ('soulseek', 'slsk-12345', 'soulseek://user/path/file.flac', 'Test Album Track', 'queued', 50000000, 0, 'track', 1, 'someuser', '/Music/Artist/Album/track.flac', 5)",
+            [],
+        )
+        .expect("Should be able to insert Soulseek download");
+
+        let (username, filename, queue_pos): (Option<String>, Option<String>, Option<i32>) = conn
+            .query_row(
+                "SELECT soulseek_username, soulseek_filename, queue_position FROM downloads WHERE source_type = 'soulseek'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+
+        assert_eq!(username, Some("someuser".to_string()));
+        assert_eq!(filename, Some("/Music/Artist/Album/track.flac".to_string()));
+        assert_eq!(queue_pos, Some(5));
+    }
+
+    #[test]
+    fn test_source_id_unique_constraint() {
+        let conn = init_db_memory().expect("Failed to initialize in-memory database");
+
+        // Insert first download
+        conn.execute(
+            "INSERT INTO downloads (source_type, source_id, source_uri, name, status, size_bytes, downloaded_bytes, media_type, media_id)
+             VALUES ('torrent', 'uniquehash', 'magnet:?test', 'Test 1', 'downloading', 1000, 0, 'movie', 1)",
+            [],
+        )
+        .expect("Should be able to insert first download");
+
+        // Try to insert duplicate source_id - should fail (inherited UNIQUE constraint from V001)
+        // Note: The original info_hash column had UNIQUE constraint which persists after rename
+        let result = conn.execute(
+            "INSERT INTO downloads (source_type, source_id, source_uri, name, status, size_bytes, downloaded_bytes, media_type, media_id)
+             VALUES ('torrent', 'uniquehash', 'magnet:?test2', 'Test 2', 'downloading', 1000, 0, 'movie', 2)",
+            [],
+        );
+
+        assert!(result.is_err(), "Duplicate source_id should be rejected");
+
+        // Different source_id works fine
+        conn.execute(
+            "INSERT INTO downloads (source_type, source_id, source_uri, name, status, size_bytes, downloaded_bytes, media_type, media_id)
+             VALUES ('soulseek', 'slsk-different', 'soulseek://test', 'Test 3', 'downloading', 1000, 0, 'track', 1)",
+            [],
+        )
+        .expect("Different source_id should be allowed");
+    }
 }

--- a/apps/backend/src/services/soulseek/engine.rs
+++ b/apps/backend/src/services/soulseek/engine.rs
@@ -1215,4 +1215,105 @@ mod tests {
         assert!(!stats.connected);
         assert_eq!(stats.active_searches, 0);
     }
+
+    #[tokio::test]
+    async fn test_get_connection_state() {
+        let engine = SoulseekEngine::new(test_config()).await.unwrap();
+        let state = engine.get_connection_state().await;
+        assert_eq!(state, ConnectionState::Disconnected);
+    }
+
+    #[tokio::test]
+    async fn test_get_search_results_nonexistent() {
+        let engine = SoulseekEngine::new(test_config()).await.unwrap();
+        let result = engine.get_search_results(12345).await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_cancel_search_nonexistent() {
+        let engine = SoulseekEngine::new(test_config()).await.unwrap();
+        let result = engine.cancel_search(12345).await;
+        // Should return error for nonexistent search
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_download_nonexistent() {
+        let engine = SoulseekEngine::new(test_config()).await.unwrap();
+        let result = engine.get_download("nonexistent-id").await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_downloads_empty() {
+        let engine = SoulseekEngine::new(test_config()).await.unwrap();
+        let downloads = engine.get_downloads().await;
+        assert!(downloads.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_cancel_download_nonexistent() {
+        let engine = SoulseekEngine::new(test_config()).await.unwrap();
+        let result = engine.cancel_download("nonexistent-id").await;
+        // Should return error for nonexistent download
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_download_without_connection() {
+        let engine = SoulseekEngine::new(test_config()).await.unwrap();
+        let result = engine
+            .download(DownloadRequest {
+                username: "testuser".to_string(),
+                filename: "/Music/test.flac".to_string(),
+                size: 1000,
+                media_type: None,
+                media_id: None,
+            })
+            .await;
+        // Should fail without connection
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_browse_user_without_connection() {
+        let engine = SoulseekEngine::new(test_config()).await.unwrap();
+        let result = engine.browse_user("someuser").await;
+        // Should fail without connection
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_uploads_empty() {
+        let engine = SoulseekEngine::new(test_config()).await.unwrap();
+        let uploads = engine.get_uploads().await;
+        assert!(uploads.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_cancel_upload_nonexistent() {
+        let engine = SoulseekEngine::new(test_config()).await.unwrap();
+        let result = engine.cancel_upload("nonexistent-id").await;
+        // Should return error for nonexistent upload
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_share_stats() {
+        let engine = SoulseekEngine::new(test_config()).await.unwrap();
+        let stats = engine.get_share_stats().await;
+        // With default config (no share dirs), should be empty
+        assert!(stats.directories.is_empty());
+        assert_eq!(stats.total_files, 0);
+        assert_eq!(stats.total_folders, 0);
+    }
+
+    #[tokio::test]
+    async fn test_subscribe() {
+        let engine = SoulseekEngine::new(test_config()).await.unwrap();
+        let _rx = engine.subscribe();
+        // Should be able to subscribe multiple times
+        let _rx2 = engine.subscribe();
+    }
 }

--- a/apps/backend/tests/soulseek_tests.rs
+++ b/apps/backend/tests/soulseek_tests.rs
@@ -1,0 +1,307 @@
+//! Integration tests for Soulseek API endpoints.
+//!
+//! These tests verify the HTTP API behavior when Soulseek is not configured,
+//! since we cannot establish real Soulseek connections in the test environment.
+
+mod common;
+
+use common::TestApp;
+
+// =============================================================================
+// Status endpoint tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_soulseek_status_without_engine() {
+    let app = TestApp::new().await;
+    let (_user_id, token) = app.create_user().await;
+    let (name, value) = app.auth_header(&token);
+
+    let response = app
+        .server()
+        .get("/api/soulseek/status")
+        .add_header(name, value)
+        .await;
+
+    response.assert_status_ok();
+    let body: serde_json::Value = response.json();
+
+    // When soulseek is not configured, should return disconnected state
+    assert_eq!(body["connected"], false);
+    assert_eq!(body["connection_state"]["state"], "disconnected");
+    assert_eq!(body["active_searches"], 0);
+    assert_eq!(body["active_downloads"], 0);
+}
+
+#[tokio::test]
+async fn test_soulseek_status_unauthenticated() {
+    let app = TestApp::new().await;
+
+    let response = app.server().get("/api/soulseek/status").await;
+
+    response.assert_status_unauthorized();
+}
+
+// =============================================================================
+// Search endpoint tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_soulseek_search_without_engine() {
+    let app = TestApp::new().await;
+    let (_user_id, token) = app.create_user().await;
+    let (name, value) = app.auth_header(&token);
+
+    let response = app
+        .server()
+        .post("/api/soulseek/search")
+        .add_header(name, value)
+        .json(&serde_json::json!({
+            "query": "test artist album"
+        }))
+        .await;
+
+    // Should return 503 Service Unavailable when Soulseek is not configured
+    response.assert_status(axum::http::StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn test_soulseek_search_empty_query() {
+    let app = TestApp::new().await;
+    let (_user_id, token) = app.create_user().await;
+    let (name, value) = app.auth_header(&token);
+
+    let response = app
+        .server()
+        .post("/api/soulseek/search")
+        .add_header(name, value)
+        .json(&serde_json::json!({
+            "query": "   "
+        }))
+        .await;
+
+    // Empty query should return 400 Bad Request
+    response.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_soulseek_search_unauthenticated() {
+    let app = TestApp::new().await;
+
+    let response = app
+        .server()
+        .post("/api/soulseek/search")
+        .json(&serde_json::json!({
+            "query": "test"
+        }))
+        .await;
+
+    response.assert_status_unauthorized();
+}
+
+// =============================================================================
+// Download endpoint tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_soulseek_download_without_engine() {
+    let app = TestApp::new().await;
+    let (_user_id, token) = app.create_user().await;
+    let (name, value) = app.auth_header(&token);
+
+    let response = app
+        .server()
+        .post("/api/soulseek/download")
+        .add_header(name, value)
+        .json(&serde_json::json!({
+            "username": "testuser",
+            "filename": "/Music/Artist/Album/track.flac",
+            "size": 50000000
+        }))
+        .await;
+
+    // Should return 503 Service Unavailable when Soulseek is not configured
+    response.assert_status(axum::http::StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn test_soulseek_download_empty_username() {
+    let app = TestApp::new().await;
+    let (_user_id, token) = app.create_user().await;
+    let (name, value) = app.auth_header(&token);
+
+    let response = app
+        .server()
+        .post("/api/soulseek/download")
+        .add_header(name, value)
+        .json(&serde_json::json!({
+            "username": "  ",
+            "filename": "/Music/test.flac",
+            "size": 1000
+        }))
+        .await;
+
+    // Empty username should return 400 Bad Request
+    response.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_soulseek_download_empty_filename() {
+    let app = TestApp::new().await;
+    let (_user_id, token) = app.create_user().await;
+    let (name, value) = app.auth_header(&token);
+
+    let response = app
+        .server()
+        .post("/api/soulseek/download")
+        .add_header(name, value)
+        .json(&serde_json::json!({
+            "username": "testuser",
+            "filename": "",
+            "size": 1000
+        }))
+        .await;
+
+    // Empty filename should return 400 Bad Request
+    response.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_soulseek_download_unauthenticated() {
+    let app = TestApp::new().await;
+
+    let response = app
+        .server()
+        .post("/api/soulseek/download")
+        .json(&serde_json::json!({
+            "username": "testuser",
+            "filename": "/Music/test.flac",
+            "size": 1000
+        }))
+        .await;
+
+    response.assert_status_unauthorized();
+}
+
+// =============================================================================
+// Downloads list endpoint tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_soulseek_list_downloads_without_engine() {
+    let app = TestApp::new().await;
+    let (_user_id, token) = app.create_user().await;
+    let (name, value) = app.auth_header(&token);
+
+    let response = app
+        .server()
+        .get("/api/soulseek/downloads")
+        .add_header(name, value)
+        .await;
+
+    // Should return 503 Service Unavailable when Soulseek is not configured
+    response.assert_status(axum::http::StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn test_soulseek_list_downloads_unauthenticated() {
+    let app = TestApp::new().await;
+
+    let response = app.server().get("/api/soulseek/downloads").await;
+
+    response.assert_status_unauthorized();
+}
+
+// =============================================================================
+// Browse endpoint tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_soulseek_browse_without_engine() {
+    let app = TestApp::new().await;
+    let (_user_id, token) = app.create_user().await;
+    let (name, value) = app.auth_header(&token);
+
+    let response = app
+        .server()
+        .get("/api/soulseek/browse/someuser")
+        .add_header(name, value)
+        .await;
+
+    // Should return 503 Service Unavailable when Soulseek is not configured
+    response.assert_status(axum::http::StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn test_soulseek_browse_unauthenticated() {
+    let app = TestApp::new().await;
+
+    let response = app.server().get("/api/soulseek/browse/someuser").await;
+
+    response.assert_status_unauthorized();
+}
+
+// =============================================================================
+// Shares endpoint tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_soulseek_shares_without_engine() {
+    let app = TestApp::new().await;
+    let (_user_id, token) = app.create_user().await;
+    let (name, value) = app.auth_header(&token);
+
+    let response = app
+        .server()
+        .get("/api/soulseek/shares")
+        .add_header(name, value)
+        .await;
+
+    // Should return 503 Service Unavailable when Soulseek is not configured
+    response.assert_status(axum::http::StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn test_soulseek_rescan_shares_without_engine() {
+    let app = TestApp::new().await;
+    let (_user_id, token) = app.create_user().await;
+    let (name, value) = app.auth_header(&token);
+
+    let response = app
+        .server()
+        .post("/api/soulseek/shares/rescan")
+        .add_header(name, value)
+        .await;
+
+    // Should return 503 Service Unavailable when Soulseek is not configured
+    response.assert_status(axum::http::StatusCode::SERVICE_UNAVAILABLE);
+}
+
+// =============================================================================
+// Uploads endpoint tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_soulseek_list_uploads_without_engine() {
+    let app = TestApp::new().await;
+    let (_user_id, token) = app.create_user().await;
+    let (name, value) = app.auth_header(&token);
+
+    let response = app
+        .server()
+        .get("/api/soulseek/uploads")
+        .add_header(name, value)
+        .await;
+
+    // Should return 503 Service Unavailable when Soulseek is not configured
+    response.assert_status(axum::http::StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn test_soulseek_uploads_unauthenticated() {
+    let app = TestApp::new().await;
+
+    let response = app.server().get("/api/soulseek/uploads").await;
+
+    response.assert_status_unauthorized();
+}


### PR DESCRIPTION
## Summary
- Add comprehensive test coverage for Soulseek integration
- Add 17 Soulseek API integration tests covering all endpoints
- Add 12 new engine unit tests for public methods
- Add 5 database migration tests for V004 multi-source downloads
- Add 7 music unified search/download integration tests
- Update test infrastructure to include Soulseek routes

## Test plan
- [x] All new tests pass locally
- [x] cargo clippy passes
- [x] cargo fmt applied
- [ ] CI passes

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)