### PR TITLE
feat: Add VPN UI integration for WireGuard management

### DIFF
--- a/apps/lcars/src/views/mod.rs
+++ b/apps/lcars/src/views/mod.rs
@@ -81,6 +81,13 @@ pub fn routes() -> Router<AppState> {
         )
         .route("/downloads/:id", axum::routing::delete(downloads::cancel))
         .route("/settings", get(settings::page))
+        // VPN routes
+        .route("/vpn/status", get(settings::vpn_status_partial))
+        .route("/vpn/connect", axum::routing::post(settings::vpn_connect))
+        .route(
+            "/vpn/disconnect",
+            axum::routing::post(settings::vpn_disconnect),
+        )
         // Search modals
         .route("/search/tv/modal", get(tv::search_modal))
         .route("/search/music/modal", get(music::search_modal))

--- a/apps/lcars/static/css/lcars.css
+++ b/apps/lcars/static/css/lcars.css
@@ -722,6 +722,110 @@ a:hover {
 .hidden { display: none; }
 .w-full { width: 100%; }
 
+/* VPN Status Indicator */
+.vpn-indicator {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.vpn-indicator.connected {
+  background-color: var(--status-available);
+  box-shadow: 0 0 8px var(--status-available);
+}
+
+.vpn-indicator.connecting {
+  background-color: var(--lcars-yellow);
+  animation: vpn-pulse 1.5s infinite;
+}
+
+.vpn-indicator.disconnected {
+  background-color: var(--lcars-tan);
+}
+
+.vpn-indicator.error {
+  background-color: var(--lcars-red);
+  box-shadow: 0 0 8px var(--lcars-red);
+}
+
+@keyframes vpn-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* VPN Widget */
+.vpn-widget {
+  background: var(--lcars-dark);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  border-left: 4px solid var(--lcars-blue);
+}
+
+.vpn-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.vpn-title {
+  font-weight: 700;
+  color: var(--lcars-text-dim);
+  font-size: 0.875rem;
+}
+
+.vpn-status-text {
+  flex: 1;
+  text-align: right;
+}
+
+.vpn-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.vpn-detail {
+  display: flex;
+  flex-direction: column;
+}
+
+.vpn-controls {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+/* VPN Warning Banner */
+.vpn-warning-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  background: rgba(204, 102, 102, 0.15);
+  border: 2px solid var(--lcars-red);
+  border-radius: 0.5rem;
+}
+
+.vpn-warning-content {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--lcars-red);
+}
+
+.vpn-warning-content svg {
+  flex-shrink: 0;
+}
+
+/* Text color utilities */
+.text-red { color: var(--lcars-red); }
+
 /* Responsive */
 @media (max-width: 768px) {
   .lcars-sidebar {
@@ -740,5 +844,14 @@ a:hover {
 
   .media-grid {
     grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  }
+
+  .vpn-warning-banner {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .vpn-details {
+    grid-template-columns: 1fr 1fr;
   }
 }

--- a/apps/lcars/templates/pages/dashboard.html
+++ b/apps/lcars/templates/pages/dashboard.html
@@ -26,6 +26,17 @@
                 {% include "partials/status_cards.html" %}
             </div>
 
+            <!-- VPN Status Widget -->
+            {% if vpn_status.configured %}
+            <section class="mb-4">
+                <div class="section-header">
+                    <h2>VPN Status</h2>
+                    <a href="/settings" class="lcars-button yellow sm">Settings</a>
+                </div>
+                {% include "partials/vpn_status.html" %}
+            </section>
+            {% endif %}
+
             <!-- Active Downloads -->
             <section class="mb-4">
                 <div class="section-header">

--- a/apps/lcars/templates/pages/downloads.html
+++ b/apps/lcars/templates/pages/downloads.html
@@ -20,6 +20,27 @@
               sse-connect="/sse/downloads">
             <h1 class="mb-4">Downloads</h1>
 
+            {% if let Some(warning) = vpn_warning %}
+            <div class="vpn-warning-banner" id="vpn-warning">
+                <div class="vpn-warning-content">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/>
+                        <path d="M12 9v4"/>
+                        <path d="M12 17h.01"/>
+                    </svg>
+                    <span>{{ warning.message }}</span>
+                </div>
+                {% if warning.show_connect_button %}
+                <button class="lcars-button blue sm"
+                        hx-post="/vpn/connect"
+                        hx-target="#vpn-warning"
+                        hx-swap="outerHTML">
+                    Connect VPN
+                </button>
+                {% endif %}
+            </div>
+            {% endif %}
+
             <!-- Active Downloads -->
             {% if !active.is_empty() %}
             <section class="mb-4">

--- a/apps/lcars/templates/pages/settings.html
+++ b/apps/lcars/templates/pages/settings.html
@@ -60,14 +60,50 @@
             </div>
 
             <div class="lcars-panel">
-                <div class="lcars-panel-accent {% if vpn_status.connected %}lcars-blue{% else %}lcars-yellow{% endif %}"></div>
+                <div class="lcars-panel-accent {% if vpn_status.status_class == "connected" %}lcars-blue{% else if vpn_status.status_class == "connecting" %}lcars-yellow{% else if vpn_status.status_class == "error" %}lcars-red{% else %}lcars-tan{% endif %}"></div>
                 <div class="lcars-panel-content">
-                    <div class="lcars-panel-title">VPN</div>
-                    {% if vpn_status.connected %}
-                    <div>Connected{% if let Some(ip) = vpn_status.ip %} ({{ ip }}){% endif %}</div>
-                    {% else %}
-                    <div>Not Connected</div>
-                    {% endif %}
+                    <div class="lcars-panel-title">WireGuard VPN</div>
+                    <div class="flex justify-between items-center">
+                        <div>
+                            <div class="flex items-center gap-2">
+                                <span class="vpn-indicator {{ vpn_status.status_class }}"></span>
+                                <span>{{ vpn_status.status }}</span>
+                            </div>
+                            {% if let Some(endpoint) = vpn_status.endpoint %}
+                            <div class="text-dim text-sm">{{ endpoint }}</div>
+                            {% endif %}
+                            {% if vpn_status.kill_switch_enabled %}
+                            <div class="text-sm {% if vpn_status.kill_switch_active %}text-red{% endif %}">
+                                Kill Switch: {% if vpn_status.kill_switch_active %}Active{% else %}Ready{% endif %}
+                            </div>
+                            {% endif %}
+                        </div>
+                        {% if vpn_status.configured %}
+                        <div class="vpn-controls">
+                            {% if vpn_status.status_class == "connected" %}
+                            <button class="lcars-button red sm"
+                                    hx-post="/vpn/disconnect"
+                                    hx-target="closest .lcars-panel"
+                                    hx-swap="outerHTML"
+                                    hx-select=".lcars-panel">
+                                Disconnect
+                            </button>
+                            {% else if vpn_status.status_class != "connecting" %}
+                            <button class="lcars-button blue sm"
+                                    hx-post="/vpn/connect"
+                                    hx-target="closest .lcars-panel"
+                                    hx-swap="outerHTML"
+                                    hx-select=".lcars-panel">
+                                Connect
+                            </button>
+                            {% else %}
+                            <button class="lcars-button tan sm" disabled>
+                                Connecting...
+                            </button>
+                            {% endif %}
+                        </div>
+                        {% endif %}
+                    </div>
                 </div>
             </div>
 

--- a/apps/lcars/templates/partials/vpn_status.html
+++ b/apps/lcars/templates/partials/vpn_status.html
@@ -1,0 +1,72 @@
+<div id="vpn-status-widget" class="vpn-widget"
+     hx-get="/vpn/status"
+     hx-trigger="every 5s"
+     hx-swap="outerHTML">
+    <div class="vpn-header">
+        <div class="vpn-indicator {{ vpn_status.status_class }}"></div>
+        <span class="vpn-title">VPN</span>
+        <span class="vpn-status-text">{{ vpn_status.status }}</span>
+    </div>
+
+    {% if vpn_status.configured %}
+    <div class="vpn-details">
+        {% if let Some(interface) = vpn_status.interface %}
+        <div class="vpn-detail">
+            <span class="text-dim text-sm">Interface</span>
+            <span>{{ interface }}</span>
+        </div>
+        {% endif %}
+
+        {% if let Some(endpoint) = vpn_status.endpoint %}
+        <div class="vpn-detail">
+            <span class="text-dim text-sm">Endpoint</span>
+            <span>{{ endpoint }}</span>
+        </div>
+        {% endif %}
+
+        {% if let Some(duration) = vpn_status.connected_since %}
+        <div class="vpn-detail">
+            <span class="text-dim text-sm">Connected</span>
+            <span>{{ duration }}</span>
+        </div>
+        {% endif %}
+
+        {% if vpn_status.kill_switch_enabled %}
+        <div class="vpn-detail">
+            <span class="text-dim text-sm">Kill Switch</span>
+            <span class="{% if vpn_status.kill_switch_active %}text-red{% else %}text-dim{% endif %}">
+                {% if vpn_status.kill_switch_active %}Active{% else %}Ready{% endif %}
+            </span>
+        </div>
+        {% endif %}
+    </div>
+
+    {% if is_admin %}
+    <div class="vpn-controls">
+        {% if vpn_status.status_class == "connected" %}
+        <button class="lcars-button red sm"
+                hx-post="/vpn/disconnect"
+                hx-target="#vpn-status-widget"
+                hx-swap="outerHTML">
+            Disconnect
+        </button>
+        {% else if vpn_status.status_class != "connecting" %}
+        <button class="lcars-button blue sm"
+                hx-post="/vpn/connect"
+                hx-target="#vpn-status-widget"
+                hx-swap="outerHTML">
+            Connect
+        </button>
+        {% else %}
+        <button class="lcars-button tan sm" disabled>
+            Connecting...
+        </button>
+        {% endif %}
+    </div>
+    {% endif %}
+    {% else %}
+    <div class="vpn-details">
+        <p class="text-dim text-sm">VPN is not configured. Add WireGuard configuration in config.toml.</p>
+    </div>
+    {% endif %}
+</div>


### PR DESCRIPTION
## Summary

Implements #69 - VPN UI integration (part of #65 - WireGuard VPN integration)

This PR adds VPN status and controls to the web UI, allowing users to monitor and manage WireGuard VPN connections.

### Features

#### Dashboard VPN Widget
- Connection status indicator (green/yellow/red)
- Current endpoint display
- Connection duration
- Kill switch status
- Quick connect/disconnect buttons (admin only)
- Auto-refresh via HTMX polling every 5 seconds

#### Settings Page Enhancement
- Real-time VPN status from WireGuard service
- Visual status indicator with color-coded states
- Kill switch status display
- Admin controls for connect/disconnect

#### Downloads Page Warning Banner
- Warning when VPN is disconnected
- Critical warning when kill switch is active
- Quick connect button to restore VPN

### New Files
- `templates/partials/vpn_status.html` - VPN status widget partial

### Modified Files
| File | Changes |
|------|---------|
| `views/dashboard.rs` | Added VPN status to dashboard template |
| `views/downloads.rs` | Added VPN warning logic |
| `views/settings.rs` | Integrated real WireGuard service status |
| `views/mod.rs` | Added VPN routes |
| `templates/pages/dashboard.html` | Added VPN widget section |
| `templates/pages/downloads.html` | Added warning banner |
| `templates/pages/settings.html` | Enhanced VPN panel |
| `static/css/lcars.css` | Added VPN-specific styles |

### New Routes
- `GET /vpn/status` - Returns VPN status HTML partial (for HTMX)
- `POST /vpn/connect` - Connect VPN (admin only)
- `POST /vpn/disconnect` - Disconnect VPN (admin only)

### CSS Additions
- `.vpn-indicator` - Status indicator with color states
- `.vpn-widget` - Widget layout
- `.vpn-warning-banner` - Warning banner styling
- Responsive design for mobile

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy` passes (no warnings)
- [x] All 146 unit tests pass
- [x] All integration tests pass
- [ ] Manual testing of dashboard VPN widget
- [ ] Manual testing of settings VPN panel
- [ ] Manual testing of downloads warning banner
- [ ] Verify HTMX polling works correctly
- [ ] Test connect/disconnect buttons

## Next Steps

- #70 - DNS leak prevention (final WireGuard issue)

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)